### PR TITLE
feat: show human-readable party abbreviations instead of plain ids

### DIFF
--- a/frontend/src/components/MPSearch.tsx
+++ b/frontend/src/components/MPSearch.tsx
@@ -1,6 +1,6 @@
 import { useMiniSearch } from "react-minisearch";
 import { useEffect, useState } from "preact/hooks";
-import { PARTY_COLORS } from "~src/constants";
+import { PARTY_ABBRS, PARTY_COLORS } from "~src/constants";
 import { getContrastingColor } from "~src/utils";
 
 // See MiniSearch for documentation on options
@@ -133,17 +133,21 @@ function MemberListItem({ mp }: MLIProps) {
                     </div>
                 )}
                 <p>
-                    <strong>
-                        {mp.first_name} {mp.last_name}
-                    </strong>
-                    <span
-                        class="party"
-                        style={{
-                            "--background": backgroundColor,
-                            "--text": textColor,
-                        }}
-                    >
-                        {mp.party_id}
+                    <span>
+                        <strong>
+                            {mp.first_name} {mp.last_name}
+                        </strong>
+                        <span
+                            class="party"
+                            style={{
+                                "--background": backgroundColor,
+                                "--text": textColor,
+                            }}
+                        >
+                            {PARTY_ABBRS[
+                                mp.party_id as keyof typeof PARTY_ABBRS
+                            ] || mp.party_id}
+                        </span>
                     </span>
 
                     <br />

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -30,3 +30,15 @@ export const PARTY_COLORS = {
     vas: "#BF1E24",
     vihr: "#61BF1A",
 };
+
+export const PARTY_ABBRS = {
+    kd: "KD",
+    kesk: "Kesk.",
+    kok: "Kok.",
+    liik: "Liik.",
+    ps: "PS",
+    r: "RKP",
+    sd: "SDP",
+    vas: "Vas.",
+    vihr: "Vihr.",
+};

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -68,14 +68,19 @@ const mpsWithPhotoUrls = await mpWithPhotoUrl(data);
         height: revert-layer;
         object-fit: cover;
     }
+    strong:has(+ .party) {
+        vertical-align: middle;
+    }
     .party {
+        font-size: 0.9em;
+        font-weight: 450;
         background-color: var(--background);
         color: var(--text);
         display: inline-block;
         text-align: center;
+        vertical-align: middle;
         margin-inline: 0.5em;
         padding: 0em 0.4em;
         border-radius: 0.125em;
-        min-width: 1em;
     }
 </style>


### PR DESCRIPTION
now instead of, e.g., "sd" or "r", we show "SDP" and "RKP"