### PR TITLE
Add government and mp proposals, Reformat parsing process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,10 @@ data/preprocessed/mp_committee_memberships.csv: pipes/mp_committee_membership_pi
 	mkdir -p data/preprocessed
 	uv run pipes/mp_committee_membership_pipe.py --preprocess-data
 
+data/preprocessed/government_proposals.csv: pipes/government_proposal_pipe.py $(DATA_DUMP)
+	mkdir -p data/preprocessed
+	uv run pipes/government_proposal_pipe.py --preprocess-data
+
 data/preprocessed/sessions.csv: pipes/session_pipe.py $(DATA_DUMP)
 	mkdir -p data/preprocessed
 	uv run pipes/session_pipe.py --preprocess-data
@@ -138,6 +142,7 @@ PREPROCESSED_FILES = $(VASKI_DATA) \
     data/preprocessed/mp_party_memberships.csv \
     data/preprocessed/committees.csv \
     data/preprocessed/mp_committee_memberships.csv \
+	data/preprocessed/government_proposals.csv \
 	data/preprocessed/sessions.csv \
 	data/preprocessed/agenda_items.csv \
     data/preprocessed/speeches.csv \
@@ -158,6 +163,7 @@ $(DATABASE): $(PREPROCESSED_FILES)
 		pipes/mp_party_membership_pipe.py \
 		pipes/committee_pipe.py \
 		pipes/mp_committee_membership_pipe.py \
+		pipes/government_proposal_pipe.py \
 		pipes/session_pipe.py \
 		pipes/agenda_item_pipe.py \
 		pipes/speech_pipe.py \

--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,6 @@ data/preprocessed/mp_committee_memberships.csv: pipes/mp_committee_membership_pi
 	mkdir -p data/preprocessed
 	uv run pipes/mp_committee_membership_pipe.py --preprocess-data
 
-data/preprocessed/government_proposals.csv: pipes/government_proposal_pipe.py $(DATA_DUMP)
-	mkdir -p data/preprocessed
-	uv run pipes/government_proposal_pipe.py --preprocess-data
-
 data/preprocessed/sessions.csv: pipes/session_pipe.py $(DATA_DUMP)
 	mkdir -p data/preprocessed
 	uv run pipes/session_pipe.py --preprocess-data
@@ -142,7 +138,6 @@ PREPROCESSED_FILES = $(VASKI_DATA) \
     data/preprocessed/mp_party_memberships.csv \
     data/preprocessed/committees.csv \
     data/preprocessed/mp_committee_memberships.csv \
-	data/preprocessed/government_proposals.csv \
 	data/preprocessed/sessions.csv \
 	data/preprocessed/agenda_items.csv \
     data/preprocessed/speeches.csv \
@@ -163,7 +158,6 @@ $(DATABASE): $(PREPROCESSED_FILES)
 		pipes/mp_party_membership_pipe.py \
 		pipes/committee_pipe.py \
 		pipes/mp_committee_membership_pipe.py \
-		pipes/government_proposal_pipe.py \
 		pipes/session_pipe.py \
 		pipes/agenda_item_pipe.py \
 		pipes/speech_pipe.py \

--- a/pipes/XML_parsing_help_functions.py
+++ b/pipes/XML_parsing_help_functions.py
@@ -109,6 +109,16 @@ def Perustelu_parse(root, NS, not_child_of=""):
 
     return reasoning
 
+def Nimeke_parse(root, NS):
+    
+    title_nodes = root.xpath(
+            f".//met:Nimeke//met1:NimekeTeksti",
+            namespaces=NS
+        )
+    title = "\n\n".join([_txt(n) for n in title_nodes])
+
+    return title
+
 def AsiaSisaltoKuvaus_parse(root, NS, not_child_of=""):
     if not_child_of:
         filter = f"[not(ancestor::{not_child_of})]"

--- a/pipes/XML_parsing_help_functions.py
+++ b/pipes/XML_parsing_help_functions.py
@@ -1,0 +1,244 @@
+import os
+import pandas as pd
+import psycopg2
+from lxml import etree
+from io import StringIO
+
+def _txt(node):
+    """Collapse all text from an element; return '' if node is None."""
+    if node is None:
+        return ""
+    return " ".join("".join(node.itertext()).split())
+
+def saados_to_md(saados, NS):
+            title_bits = []
+            stype = _txt(saados.find(".//saa:SaadostyyppiKooste", namespaces=NS))
+            sname = _txt(saados.find(".//saa:SaadosNimekeKooste", namespaces=NS))
+            num = _txt(saados.find(".//saa:LakiehdotusNumeroKooste", namespaces=NS))
+            if num: title_bits.append(num)
+            if stype: title_bits.append(stype)
+            if sname: title_bits.append(sname)
+            header = " ".join(title_bits).strip()
+            out = []
+            if header:
+                out.append(f"### {header}")
+
+            # Johtolause (preamble)
+            for jl in saados.findall(".//saa:Johtolause", namespaces=NS):
+                for p in jl.findall(".//saa:SaadosKappaleKooste", namespaces=NS):
+                    txt = _txt(p)
+                    if txt:
+                        out.append(txt)
+
+            # Pykälät
+            for pyk in saados.findall(".//saa:Pykala", namespaces=NS):
+                pykno = _txt(pyk.find(".//saa:PykalaTunnusKooste", namespaces=NS))
+                ots = _txt(pyk.find(".//saa:SaadosOtsikkoKooste", namespaces=NS))
+                head = f"**{pykno} {ots}**".strip()
+                if head and head != "** **":
+                    out.append(head)
+
+                for mom in pyk.findall(".//saa:MomenttiKooste", namespaces=NS):
+                    mtxt = _txt(mom)
+                    if mtxt:
+                        out.append(mtxt)
+
+                for km in pyk.findall(".//saa:KohdatMomentti", namespaces=NS):
+                    johd = _txt(km.find(".//saa:MomenttiJohdantoKooste", namespaces=NS))
+                    if johd:
+                        out.append(johd)
+                    for k in km.findall(".//saa:MomenttiKohtaKooste", namespaces=NS):
+                        kt = _txt(k)
+                        if kt:
+                            out.append(f"- {kt}")
+
+            return "\n\n".join(out)
+
+def parse_tau_table(table_element):
+    """
+    Parse a <tau:table> XML element into a JSON-friendly dict:
+    {
+      "title": "...",
+      "rows": [
+        {"column_1": "...", "column_2": "...", "column_3": ["...", "..."]},
+        ...
+      ]
+    }
+    """
+    namespaces = {'tau': 'tau', 'sis': 'sis'}
+
+    result = {}
+    # Capture table title if it exists
+    title_elem = table_element.find(".//tau:title/sis:KappaleKooste", namespaces)
+    if title_elem is not None:
+        result["title"] = title_elem.text.strip()
+
+    rows = []
+    for row in table_element.findall(".//tau:row", namespaces):
+        entries = row.findall("tau:entry", namespaces)
+        row_data = {}
+        for idx, entry in enumerate(entries, start=1):
+            # Collect all kappale texts from the entry
+            kappale_list = entry.findall("sis:KappaleKooste", namespaces)
+            values = [k.text.strip() for k in kappale_list if k.text and k.text.strip()]
+
+            if not values and entry.text and entry.text.strip():
+                values.append(entry.text.strip())
+
+            # Store list if multiple values, string if single, None if empty
+            row_data[f"column_{idx}"] = values[0] if len(values) == 1 else (values or None)
+        rows.append(row_data)
+
+    result["rows"] = rows
+    return result
+
+def Perustelu_parse(root, NS, not_child_of=""):
+    if not_child_of:
+        filter = f"[not(ancestor::{not_child_of})]"
+    else:
+        filter = ""
+
+    reasoning_nodes = root.xpath(
+            f".//asi:PerusteluOsa{filter}//sis1:OtsikkoTeksti | "
+            f".//asi:PerusteluOsa{filter}//sis1:ValiotsikkoTeksti | "
+            f".//asi:PerusteluOsa{filter}//sis:KappaleKooste | "
+            f".//asi:PerusteluOsa{filter}//sis:SisennettyKappaleKooste",
+            namespaces=NS
+        )
+    reasoning = "\n\n".join([_txt(n) for n in reasoning_nodes])
+
+    return reasoning
+
+def AsiaSisaltoKuvaus_parse(root, NS, not_child_of=""):
+    if not_child_of:
+        filter = f"[not(ancestor::{not_child_of})]"
+    else:
+        filter = ""
+
+    summary_nodes = root.xpath(
+            f".//vsk:AsiaKuvaus//sis:KappaleKooste{filter} | "
+            f".//asi:SisaltoKuvaus//sis:KappaleKooste{filter}",
+            namespaces=NS
+        )
+    summary = "\n\n".join([_txt(n) for n in summary_nodes])
+
+    return summary
+
+def Ponsi_parse(root, NS):
+    ponsi_nodes = root.xpath(
+            f".//asi:PonsiOsa//sis1:OtsikkoTeksti | "
+            f".//asi:PonsiOsa//asi1:JohdantoTeksti | "
+            f".//asi:PonsiOsa//sis:KappaleKooste | "
+            f".//asi:PonsiOsa//sis:SisennettyKappaleKooste |"
+            f".//asi:PonsiOsa//sis1:KappaleKooste |"
+            f".//asi:PonsiOsa//sis1:SisennettyKappaleKooste",
+            namespaces=NS
+        )
+    ponsi = "\n\n".join([_txt(n) for n in ponsi_nodes])
+
+    return ponsi
+
+
+
+
+
+def Saados_parse(root, NS):
+    law_md_blocks = []
+    for saados in root.findall(".//saa:SaadosOsa/saa:Saados", namespaces=NS):
+        law_md = saados_to_md(saados, NS)
+        if law_md:
+            law_md_blocks.append(law_md)
+    law_changes = "\n\n---\n\n".join(law_md_blocks)
+
+    return law_changes
+
+def status_parse(handling_root, handling_xml_str, NS):
+    handling_root = etree.parse(StringIO(handling_xml_str)).getroot()
+    status = handling_root.find(".//vsk:EduskuntakasittelyPaatosKuvaus", namespaces=NS).attrib.get(f"{{{NS['vsk1']}}}eduskuntakasittelyPaatosKoodi")
+    match status:
+        case None:
+            status = "open"
+        case "Expired" | "Cancelled" | "Rejected" | "Resting" | "Passed":
+            status = status.lower()
+        case "PassedChanged":
+            status = "passed_changed"
+        case "PassedUrgent":
+            status = "passed_urgent"
+        case _:
+            Exception
+
+    return status
+
+def Paatos_parse(root, NS, not_child_of=""):
+    if not_child_of:
+        filter = f"[not(ancestor::{not_child_of})]"
+    else:
+        filter = ""
+
+    op_nodes = root.xpath(
+            f".//vsk:PaatosOsa//sis1:OtsikkoTeksti{filter} | "
+            f".//vsk:PaatosOsa//asi1:JohdantoTeksti{filter} | "
+            f".//vsk:PaatosOsa//sis:KappaleKooste{filter} | "
+            f".//vsk:PaatosOsa//sis:SisennettyKappaleKooste{filter}",
+            namespaces=NS
+        )
+    opinion = "\n\n".join([_txt(n) for n in op_nodes])
+
+    return opinion
+
+def Allekirjoittaja_parse(root, NS, eid, cursor=None):
+    sgn_records = []
+    for signer in root.findall(".//asi:Allekirjoittaja", namespaces=NS):
+            if signer.find(".//org:Henkilo/org1:EtuNimi", namespaces=NS).text is None:       # Joskus nää on vaan jostain syystä tyhjiä
+                continue
+            mp_id = signer.find(".//org:Henkilo", namespaces=NS).attrib.get(f"{{{NS['met1']}}}muuTunnus")
+            if mp_id is None:
+                first_name = signer.find(".//org:Henkilo/org1:EtuNimi", namespaces=NS).text
+                last_name = signer.find(".//org:Henkilo/org1:SukuNimi", namespaces=NS).text
+                if not first_name or not last_name:                         # Joskus nääki voi puuttua huoh
+                    continue
+
+                # Joskus sukunimen yhteydessä on puolue
+                if len(last_name.split()) > 1 and last_name.split()[-1].endswith(("ps", "kok", "vihr", "sd", "r", "liik", "kesk", "vas")):
+                    last_name = "".join(last_name.split()[:-1]).strip()
+
+                cursor.execute("""
+                    SELECT id 
+                    FROM public.members_of_parliament 
+                    WHERE LOWER(first_name) = %s AND LOWER(last_name) = %s""", 
+                    (first_name.strip().lower(), last_name.strip().lower())
+                    )
+                
+                mp_id = cursor.fetchone()
+                if mp_id is not None:
+                    mp_id = mp_id[0]
+                else:
+                    # Tänne menee sihteerit yms. jotka on joskus allekirjoittamassa esityksiä
+                    continue
+
+            if signer.attrib.get(f"{{{NS['asi1']}}}allekirjoitusLuokitusKoodi") == "EnsimmainenAllekirjoittaja":     # Hallitusten esityksissä ei kai käytetä tätä systeemiä
+                first = 1                                                                                       # joten tää on käytännössä vielä testaamatta
+            else:
+                first = 0
+
+            sgn_records.append({
+                "government_proposal_id": eid.lower(),
+                "mp_id": int(mp_id),
+                "first": first
+            })
+    return sgn_records
+
+def Osallistuja_parse(root, NS, eid):
+    sgn_records = []
+    for person in root.findall(".//vsk:OsallistujaOsa//org:Henkilo", namespaces=NS):
+            mp_id = person.get(f"{{{NS['met1']}}}muuTunnus", "").strip()
+            if mp_id.isdigit():
+                sgn_records.append({"committee_report_id": eid.lower(), "mp_id": int(mp_id)})
+
+    return sgn_records
+
+def id_parse(root, NS):
+    metadata = root.find(".//jme:JulkaisuMetatieto", namespaces=NS)
+    eid = metadata.get(f"{{{NS['met1']}}}eduskuntaTunnus", "").strip()
+
+    return eid

--- a/pipes/government_proposal_pipe.py
+++ b/pipes/government_proposal_pipe.py
@@ -1,0 +1,161 @@
+import os
+import csv
+import pandas as pd
+import psycopg2
+from lxml import etree
+from io import StringIO
+from XML_parsing_help_functions import id_parse, AsiaSisaltoKuvaus_parse, Perustelu_parse, Saados_parse, status_parse, Allekirjoittaja_parse
+
+# Paths
+gp_tsv_path = os.path.join("data", "raw", "vaski", "GovernmentProposal_fi.tsv")
+government_proposals_csv = os.path.join("data", "preprocessed", "government_proposals.csv")
+government_proposal_signatures_csv = os.path.join("data", "preprocessed", "government_proposal_signatures.csv")
+handling_tsv_path = os.path.join("data", "raw", "vaski", "KasittelytiedotValtiopaivaasia_fi.tsv")
+
+# Namespaces
+NS = {
+    'asi': 'http://www.vn.fi/skeemat/asiakirjakooste/2010/04/27',
+    'asi1': 'http://www.vn.fi/skeemat/asiakirjaelementit/2010/04/27',
+    'met': 'http://www.vn.fi/skeemat/metatietokooste/2010/04/27',
+    'met1': 'http://www.vn.fi/skeemat/metatietoelementit/2010/04/27',
+    'org': 'http://www.vn.fi/skeemat/organisaatiokooste/2010/02/15',
+    'org1': 'http://www.vn.fi/skeemat/organisaatioelementit/2010/02/15',
+    'sis': 'http://www.vn.fi/skeemat/sisaltokooste/2010/04/27',
+    'sis1': 'http://www.vn.fi/skeemat/sisaltoelementit/2010/04/27',
+    'vml': 'http://www.eduskunta.fi/skeemat/mietinto/2011/01/04',
+    'vsk': 'http://www.eduskunta.fi/skeemat/vaskikooste/2011/01/04',
+    'vsk1': 'http://www.eduskunta.fi/skeemat/vaskielementit/2011/01/04',
+    'saa': 'http://www.vn.fi/skeemat/saadoskooste/2010/04/27',
+    'saa1': 'http://www.vn.fi/skeemat/saadoselementit/2010/04/27',
+    'vas': 'http://www.eduskunta.fi/skeemat/vastalause/2011/01/04',
+    'jme': 'http://www.eduskunta.fi/skeemat/julkaisusiirtokooste/2011/12/20',
+    'ns11': 'http://www.eduskunta.fi/skeemat/siirto/2011/09/07',
+    'ns4': 'http://www.eduskunta.fi/skeemat/siirtoelementit/2011/05/17',
+    's359': 'http://www.vn.fi/skeemat/metatietoelementit/2010/04/27',
+    's360': 'http://www.vn.fi/skeemat/metatietoelementit/2010/04/27',
+    'sii': 'http://www.eduskunta.fi/skeemat/siirtokooste/2011/05/17',
+    'sii1': 'http://www.eduskunta.fi/skeemat/siirtoelementit/2011/05/17',
+    'he': 'http://www.vn.fi/skeemat/he/2010/04/27',
+    'tau': 'http://www.vn.fi/skeemat/taulukkokooste/2010/04/27',
+    'mix': 'http://www.loc.gov/mix/v20',
+    'narc': 'http://www.narc.fi/sahke2/2010-09_vnk',
+    'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+    'def': 'http://www.eduskunta.fi/skeemat/siirtokooste/2011/05/17'
+}
+
+
+def preprocess_data():
+    os.makedirs(os.path.dirname(government_proposals_csv), exist_ok=True)
+    gp_df = pd.read_csv(gp_tsv_path, sep="\t")
+    handling_df = pd.read_csv(handling_tsv_path, sep="\t")
+
+    gp_records = []            # government_proposals rows
+    sgn_records = []  
+
+    conn = psycopg2.connect(
+        database="postgres",
+        host="db",
+        user="postgres",
+        password="postgres",
+        port="5432"
+        )
+
+    cur = conn.cursor()          
+
+    for gp_xml_str in gp_df.get("XmlData", []):
+
+        gp_root = etree.parse(StringIO(gp_xml_str)).getroot()
+
+        # ID
+        eid = id_parse(gp_root, NS)
+        if eid[:2] == "RP":                                                             # Joskus tänne on sattunu ruotsinkielisiä versioita                
+            if gp_df.loc[gp_df['Eduskuntatunnus'] == f"HE{eid[2:-2]}vp"] is not None:   # Tsekataan löytyykö sama suomeksi
+                continue                                                                # Jos löytyy niin skipataan ruotsinkielinen versio ja 
+            else:                                                                       # oletetaan että suomenkielinen on tulossa/mennyt
+                Exception
+
+        proposal = gp_root.find(".//he:HallituksenEsitys", namespaces=NS)
+        if proposal is None:
+            continue
+        
+        # SUMMARY
+        summary = AsiaSisaltoKuvaus_parse(proposal, NS)
+
+        # REASONING
+        reasoning = Perustelu_parse(proposal, NS)
+
+        # LAW_CHANGES
+        law_changes = Saados_parse(proposal, NS)
+
+        # STATUS
+        handling_xml_str = handling_df.loc[handling_df['Eduskuntatunnus'] == eid].get("XmlData", "").tolist()[0] 
+        handling_root = etree.parse(StringIO(handling_xml_str)).getroot()
+        status = status_parse(handling_root, handling_xml_str, NS)
+
+        gp_records.append({
+                "id": eid.lower(),
+                "proposer": "government",
+                "summary": summary,
+                "reasoning": reasoning,
+                "law_changes": law_changes,
+                "status": status
+            })
+
+        # SIGNATURES
+        sgn_records.extend(Allekirjoittaja_parse(proposal, NS, eid, cur))
+
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    pd.DataFrame(gp_records).to_csv(government_proposals_csv, index=False, encoding="utf-8")
+    pd.DataFrame(sgn_records).to_csv(government_proposal_signatures_csv, index=False, encoding="utf-8")
+
+
+def import_data():
+    conn = psycopg2.connect(
+        database="postgres",
+        host="db",
+        user="postgres",
+        password="postgres",
+        port="5432"
+    )
+    cur = conn.cursor()
+
+    with open(government_proposals_csv, "r", encoding="utf-8") as f:
+        cur.copy_expert(
+            """
+            COPY proposals(id, proposer, summary, reasoning, law_changes, status)
+            FROM STDIN WITH (FORMAT CSV, HEADER TRUE, QUOTE '\"');
+            """,
+            f
+        )
+
+    with open(government_proposal_signatures_csv, "r", encoding="utf-8") as f:
+        cur.copy_expert(
+            """
+            COPY proposal_signatures(proposal_id, mp_id, first)
+            FROM STDIN WITH (FORMAT CSV, HEADER TRUE, QUOTE '\"');
+            """,
+            f
+        )
+        
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preprocess-data", action="store_true", help="Parse TSV and write CSVs")
+    parser.add_argument("--import-data", action="store_true", help="Import CSVs into Postgres")
+    args = parser.parse_args()
+
+    if args.preprocess_data:
+        preprocess_data()
+    if args.import_data:
+        import_data()
+    if not args.preprocess_data and not args.import_data:
+        preprocess_data()
+        import_data()

--- a/pipes/mp_proposal_pipe.py
+++ b/pipes/mp_proposal_pipe.py
@@ -48,8 +48,6 @@ def preprocess_data():
     os.makedirs(os.path.dirname(mp_proposals_csv), exist_ok=True)
     mpp_df = pd.read_csv(mp_proposal_tsv_path, sep="\t")
     handling_df = pd.read_csv(handling_tsv_path, sep="\t")
-    
-    n = 0
 
     mpp_records = []            # government_proposals rows
     sgn_records = []  

--- a/pipes/mp_proposal_pipe.py
+++ b/pipes/mp_proposal_pipe.py
@@ -7,9 +7,9 @@ from io import StringIO
 from XML_parsing_help_functions import id_parse, Nimeke_parse, AsiaSisaltoKuvaus_parse, Perustelu_parse, Saados_parse, status_parse, Allekirjoittaja_parse
 
 # Paths
-gp_tsv_path = os.path.join("data", "raw", "vaski", "GovernmentProposal_fi.tsv")
-government_proposals_csv = os.path.join("data", "preprocessed", "government_proposals.csv")
-government_proposal_signatures_csv = os.path.join("data", "preprocessed", "government_proposal_signatures.csv")
+mp_proposal_tsv_path = os.path.join("data", "raw", "vaski", "LegislativeMotion_fi.tsv")
+mp_proposals_csv = os.path.join("data", "preprocessed", "mp_proposals.csv")
+mp_proposal_signatures_csv = os.path.join("data", "preprocessed", "mp_proposal_signatures.csv")
 handling_tsv_path = os.path.join("data", "raw", "vaski", "KasittelytiedotValtiopaivaasia_fi.tsv")
 
 # Namespaces
@@ -40,16 +40,18 @@ NS = {
     'mix': 'http://www.loc.gov/mix/v20',
     'narc': 'http://www.narc.fi/sahke2/2010-09_vnk',
     'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-    'def': 'http://www.eduskunta.fi/skeemat/siirtokooste/2011/05/17'
+    'def': 'http://www.eduskunta.fi/skeemat/siirtokooste/2011/05/17',
+    'eka': "http://www.eduskunta.fi/skeemat/eduskuntaaloite/2012/08/10"
 }
 
-
 def preprocess_data():
-    os.makedirs(os.path.dirname(government_proposals_csv), exist_ok=True)
-    gp_df = pd.read_csv(gp_tsv_path, sep="\t")
+    os.makedirs(os.path.dirname(mp_proposals_csv), exist_ok=True)
+    mpp_df = pd.read_csv(mp_proposal_tsv_path, sep="\t")
     handling_df = pd.read_csv(handling_tsv_path, sep="\t")
+    
+    n = 0
 
-    gp_records = []            # government_proposals rows
+    mpp_records = []            # government_proposals rows
     sgn_records = []  
 
     conn = psycopg2.connect(
@@ -59,62 +61,45 @@ def preprocess_data():
         password="postgres",
         port="5432"
         )
-
+    
     cur = conn.cursor()          
 
-    for gp_xml_str in gp_df.get("XmlData", []):
+    for mpp_xml_str in mpp_df.get("XmlData", []):
 
-        gp_root = etree.parse(StringIO(gp_xml_str)).getroot()
+        mpp_root = etree.parse(StringIO(mpp_xml_str)).getroot()
 
-        # ID
-        eid = id_parse(gp_root, NS)
-        if eid[:2] == "RP":                                                             # Joskus tänne on sattunu ruotsinkielisiä versioita                
-            if gp_df.loc[gp_df['Eduskuntatunnus'] == f"HE{eid[2:-2]}vp"] is not None:   # Tsekataan löytyykö sama suomeksi
-                continue                                                                # Jos löytyy niin skipataan ruotsinkielinen versio ja 
-            else:                                                                       # oletetaan että suomenkielinen on tulossa/mennyt
+        eid = id_parse(mpp_root, NS)
+
+        proposal = mpp_root.find(".//eka:Lakialoite", namespaces=NS)
+        if proposal is None:                                                # Joskus oikean aloitteen lisäksi on tyhjä aloite samalla id:llä                         
+            if len(mpp_df.loc[mpp_df['Eduskuntatunnus'] == eid]) > 1:       # Tarkistetaan että samalla id:llä löytyy toinenkin (oikea) aloite
+                continue                                                    # Skipataan tämä           
+            elif eid == "LA 78/2017 vp":    # 2017 itsenäisyyspäivänä perustettu Itsenäisyyden juhlavuoden lastensäätiö perustettiin lakialoitteena                                                                       
+                continue
+            else:
                 raise Exception
 
-        proposal = gp_root.find(".//he:HallituksenEsitys", namespaces=NS)
-        if proposal is None:
-            continue
-
-        # TITLE
-        title = Nimeke_parse(proposal, NS)
-        
-        # SUMMARY
-        summary = AsiaSisaltoKuvaus_parse(proposal, NS)
-
-        # REASONING
-        reasoning = Perustelu_parse(proposal, NS)
-
-        # LAW_CHANGES
-        law_changes = Saados_parse(proposal, NS)
-
-        # STATUS
         handling_xml_str = handling_df.loc[handling_df['Eduskuntatunnus'] == eid].get("XmlData", "").tolist()[0] 
         handling_root = etree.parse(StringIO(handling_xml_str)).getroot()
-        status = status_parse(handling_root, handling_xml_str, NS)
 
-        gp_records.append({
-                "id": eid.lower(),
-                "proposer": "government",
-                "title": title,
-                "summary": summary,
-                "reasoning": reasoning,
-                "law_changes": law_changes,
-                "status": status
+        mpp_records.append({
+            "id": eid.lower(),
+            "proposer": "mp",
+            "title": Nimeke_parse(proposal, NS),
+            "summary": AsiaSisaltoKuvaus_parse(proposal, NS),
+            "reasoning": Perustelu_parse(proposal, NS),
+            "law_changes": Saados_parse(proposal, NS),
+            "status": status_parse(handling_root, handling_xml_str, NS)
             })
-
-        # SIGNATURES
+        
         sgn_records.extend(Allekirjoittaja_parse(proposal, NS, eid, cur))
-
+    
     conn.commit()
     cur.close()
     conn.close()
 
-    pd.DataFrame(gp_records).to_csv(government_proposals_csv, index=False, encoding="utf-8")
-    pd.DataFrame(sgn_records).to_csv(government_proposal_signatures_csv, index=False, encoding="utf-8")
-
+    pd.DataFrame(mpp_records).to_csv(mp_proposals_csv, index=False, encoding="utf-8")
+    pd.DataFrame(sgn_records).drop_duplicates().to_csv(mp_proposal_signatures_csv, index=False, encoding="utf-8")
 
 def import_data():
     conn = psycopg2.connect(
@@ -126,7 +111,7 @@ def import_data():
     )
     cur = conn.cursor()
 
-    with open(government_proposals_csv, "r", encoding="utf-8") as f:
+    with open(mp_proposals_csv, "r", encoding="utf-8") as f:
         cur.copy_expert(
             """
             COPY proposals(id, proposer, title, summary, reasoning, law_changes, status)
@@ -135,7 +120,7 @@ def import_data():
             f
         )
 
-    with open(government_proposal_signatures_csv, "r", encoding="utf-8") as f:
+    with open(mp_proposal_signatures_csv, "r", encoding="utf-8") as f:
         cur.copy_expert(
             """
             COPY proposal_signatures(proposal_id, mp_id, first)
@@ -148,7 +133,7 @@ def import_data():
     cur.close()
     conn.close()
 
-
+    
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()

--- a/postgres-init-scripts/01_create_tables.sql
+++ b/postgres-init-scripts/01_create_tables.sql
@@ -135,7 +135,8 @@ END $$;
 CREATE TABLE IF NOT EXISTS proposals (
     id VARCHAR(20) PRIMARY KEY NOT NULL,
     proposer proposal_proposer,
-    summary TEXT NOT NULL,
+    title VARCHAR(1000),
+    summary TEXT,
     reasoning TEXT NOT NULL,
     law_changes TEXT,
     status proposal_status NOT NULL

--- a/postgres-init-scripts/01_create_tables.sql
+++ b/postgres-init-scripts/01_create_tables.sql
@@ -119,6 +119,37 @@ CREATE TABLE IF NOT EXISTS speeches (
     response_to VARCHAR(15) REFERENCES speeches(id)
 );
 
+DO $$ BEGIN  
+    CREATE TYPE proposal_proposer AS ENUM ('government', 'citizen', 'mp');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN  
+    CREATE TYPE proposal_status AS ENUM ('open', 'expired', 'cancelled', 'rejected', 'resting', 'passed', 'passed_changed', 'passed_urgent');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- proposals
+CREATE TABLE IF NOT EXISTS proposals (
+    id VARCHAR(20) PRIMARY KEY NOT NULL,
+    proposer proposal_proposer,
+    summary TEXT NOT NULL,
+    reasoning TEXT NOT NULL,
+    law_changes TEXT,
+    status proposal_status NOT NULL
+);
+
+-- proposal_signatures
+CREATE TABLE IF NOT EXISTS proposal_signatures (
+    proposal_id VARCHAR(20) REFERENCES proposals(id),
+    mp_id INT REFERENCES members_of_parliament(id),
+    first BOOLEAN,
+    PRIMARY KEY(proposal_id, mp_id)
+);
+
+
 -- committee_reports
 CREATE TABLE IF NOT EXISTS committee_reports (
     id VARCHAR(20) PRIMARY KEY NOT NULL,


### PR DESCRIPTION
Tarkotus olis että sekä hallituksen, yksittäisten kansanedustajien ja kansalaisen (kansalaisaloite) tekemät lakiesitykset tallennetaan samaan tauluun. Tässä on nyt implementoitu hallitus ja mp niistä kolmesta, mutta koska mp taulu pitää olla tietokannassa ennen kun nää voi ajaa niin niitä ei oo vielä lisätty Makeen. 

Lisäksi reformatoin samalla noi parsefunktiot apufunktioiksi toiseen filuun niin pysyy siistinä. Putsailin kans vähän sloppia samalla ja nää on nyt puhdasta suomalaista käsityötä :)