### PR TITLE
feat: optimize vaski parsing

### DIFF
--- a/pipes/vaski_parser.py
+++ b/pipes/vaski_parser.py
@@ -1,37 +1,22 @@
 import os.path
-import pandas as pd
-import numpy as np
-from lxml import etree
+import polars as pl
 from tqdm import tqdm
 
 
 def vaski_parser():
-    pd.options.mode.copy_on_write = True  # Silence a warning about pandas. See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
-
     vaski_fname = os.path.join("data", "raw", "VaskiData.tsv")
 
-    for vaski_data in tqdm(pd.read_csv(vaski_fname, sep="\t", chunksize=10000), total=31):  # Total achieved by experiment
-        vaski_data['Xml'] = vaski_data["XmlData"].apply(
-            lambda x: etree.fromstring(x)
+    for vaski_data in tqdm(pl.read_csv(vaski_fname, separator="\t", has_header=True).iter_slices(n_rows=10_000), total=31):  # Total achieved by experiment
+        vaski_data = vaski_data.with_columns(
+            pl.col("XmlData").str.extract(r"VASKI_JULKVP_(\w+)").alias("doctype")
         )
-        vaski_data = vaski_data[  # Only keep finnish files
-            vaski_data['Xml'].apply(
-                lambda x: x[0][0].text.endswith('_fi')
-            )
-        ]
-        vaski_data['doctype'] = vaski_data['Xml'].apply(
-            lambda x: x[0][0].text[13:]  # All doctypes start with VASKI_JULKVP_
-        )
+        vaski_data = vaski_data.filter(pl.col("doctype").str.ends_with("_fi"))
 
-        for doctype in vaski_data['doctype'].unique():
-            sub_vaski = vaski_data[vaski_data['doctype'] == doctype].drop(
-                columns=["doctype", 'Xml']
-            )
+        for (doctype,), sub_vaski in vaski_data.group_by("doctype"):
             f_path = os.path.join("data", "raw", "vaski", f"{doctype}.tsv")            
-            if not os.path.exists(f_path):  # If no file, write header
-                sub_vaski.to_csv(f_path, sep="\t", header=True, index=False)
-            else:  # If file, no header and append
-                sub_vaski.to_csv(f_path, sep="\t", header=False, index=False, mode='a')
+            sub_vaski = sub_vaski.drop("doctype")
+            with open(f_path, mode="a" if os.path.exists(f_path) else "w") as f:
+                sub_vaski.write_csv(f, separator="\t", include_header=f.mode == "w")
 
 if __name__ == "__main__":
     vaski_parser()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "lxml>=6.0.0",
     "pandas>=2.3.0",
+    "polars>=1.33.1",
     "psycopg2-binary>=2.9.10",
     "sqlalchemy>=2.0.41",
     "tqdm>=4.67.1",

--- a/uv.lock
+++ b/uv.lock
@@ -160,6 +160,20 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/da/8246f1d69d7e49f96f0c5529057a19af1536621748ef214bbd4112c83b8e/polars-1.33.1.tar.gz", hash = "sha256:fa3fdc34eab52a71498264d6ff9b0aa6955eb4b0ae8add5d3cb43e4b84644007", size = 4822485, upload-time = "2025-09-09T08:37:49.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/79/c51e7e1d707d8359bcb76e543a8315b7ae14069ecf5e75262a0ecb32e044/polars-1.33.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3881c444b0f14778ba94232f077a709d435977879c1b7d7bd566b55bd1830bb5", size = 39132875, upload-time = "2025-09-09T08:36:38.609Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/15/1094099a1b9cb4fbff58cd8ed3af8964f4d22a5b682ea0b7bb72bf4bc3d9/polars-1.33.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:29200b89c9a461e6f06fc1660bc9c848407640ee30fe0e5ef4947cfd49d55337", size = 35638783, upload-time = "2025-09-09T08:36:43.748Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b9/9ac769e4d8e8f22b0f2e974914a63dd14dec1340cd23093de40f0d67d73b/polars-1.33.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:444940646e76342abaa47f126c70e3e40b56e8e02a9e89e5c5d1c24b086db58a", size = 39742297, upload-time = "2025-09-09T08:36:47.132Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/26/4c5da9f42fa067b2302fe62bcbf91faac5506c6513d910fae9548fc78d65/polars-1.33.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:094a37d06789286649f654f229ec4efb9376630645ba8963b70cb9c0b008b3e1", size = 36684940, upload-time = "2025-09-09T08:36:50.561Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a6/dc535da476c93b2efac619e04ab81081e004e4b4553352cd10e0d33a015d/polars-1.33.1-cp39-abi3-win_amd64.whl", hash = "sha256:c9781c704432a2276a185ee25898aa427f39a904fbe8fde4ae779596cdbd7a9e", size = 39456676, upload-time = "2025-09-09T08:36:54.612Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4e/a4300d52dd81b58130ccadf3873f11b3c6de54836ad4a8f32bac2bd2ba17/polars-1.33.1-cp39-abi3-win_arm64.whl", hash = "sha256:c3cfddb3b78eae01a218222bdba8048529fef7e14889a71e33a5198644427642", size = 35445171, upload-time = "2025-09-09T08:36:58.043Z" },
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.10"
 source = { registry = "https://pypi.org/simple" }
@@ -286,6 +300,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "lxml" },
     { name = "pandas" },
+    { name = "polars" },
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
     { name = "tqdm" },
@@ -296,6 +311,7 @@ dependencies = [
 requires-dist = [
     { name = "lxml", specifier = ">=6.0.0" },
     { name = "pandas", specifier = ">=2.3.0" },
+    { name = "polars", specifier = ">=1.33.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "tqdm", specifier = ">=4.67.1" },


### PR DESCRIPTION
hitaus harmitti ku testaili github actionsei, ni tiputetaas vaski parseri 3min -> 10s

ekaks profiloidaan mistä hitaus tulee, `line_profiler` on kiva ja asentuu `uv add line_profiler`

sit profiloidaan ite skribula `uv run kernprof -l -v pipes/vaski_parser.py`:

```
Timer unit: 1e-06 s

Total time: 185.304 s
File: pipes/vaski_parser.py
Function: vaski_parser at line 9

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     9                                           @profile
    10                                           def vaski_parser():
    11         1         81.1     81.1      0.0      pd.options.mode.copy_on_write = True  # Silence a warning about pandas. See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
    12                                           
    13         1         15.5     15.5      0.0      vaski_fname = os.path.join("data", "raw", "VaskiData.tsv")
    14                                           
    15        32   73644115.8  2.3e+06     39.7      for vaski_data in tqdm(pd.read_csv(vaski_fname, sep="\t", chunksize=10000), total=31):  # Total achieved by experiment
    16        62   59057615.8 952542.2     31.9          vaski_data['Xml'] = vaski_data["XmlData"].apply(
    17        31         37.9      1.2      0.0              lambda x: etree.fromstring(x)
    18                                                   )
    19        62      57218.3    922.9      0.0          vaski_data = vaski_data[  # Only keep finnish files
    20        62     471448.0   7604.0      0.3              vaski_data['Xml'].apply(
    21        31         28.8      0.9      0.0                  lambda x: x[0][0].text.endswith('_fi')
    22                                                       )
    23                                                   ]
    24        62     341058.9   5500.9      0.2          vaski_data['doctype'] = vaski_data['Xml'].apply(
    25        31         28.2      0.9      0.0              lambda x: x[0][0].text[13:]  # All doctypes start with VASKI_JULKVP_
    26                                                   )
    27                                           
    28      1423      17664.2     12.4      0.0          for doctype in vaski_data['doctype'].unique():
    29      2784    3080048.6   1106.3      1.7              sub_vaski = vaski_data[vaski_data['doctype'] == doctype].drop(
    30      1392       1062.6      0.8      0.0                  columns=["doctype", 'Xml']
    31                                                       )
    32      1392      20919.4     15.0      0.0              f_path = os.path.join("data", "raw", "vaski", f"{doctype}.tsv")            
    33      1392      21747.1     15.6      0.0              if not os.path.exists(f_path):  # If no file, write header
    34                                                           sub_vaski.to_csv(f_path, sep="\t", header=True, index=False)
    35                                                       else:  # If file, no header and append
    36      1392   48591207.5  34907.5     26.2                  sub_vaski.to_csv(f_path, sep="\t", header=False, index=False, mode='a')
```

kesto 180s, 30% ajasta menee xmlän parsimiseen, mut me ei tehä sil oikeestaa mitää ja voidaa vaa käyttää nopeit regexei tsekkaa doctype ja kieli.

```
Timer unit: 1e-06 s

Total time: 110.598 s
File: pipes/vaski_parser.py
Function: vaski_parser at line 9

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     9                                           @profile
    10                                           def vaski_parser():
    11         1         87.6     87.6      0.0      pd.options.mode.copy_on_write = True  # Silence a warning about pandas. See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
    12                                           
    13         1         16.5     16.5      0.0      vaski_fname = os.path.join("data", "raw", "VaskiData.tsv")
    14                                           
    15        32   56743866.1 1.77e+06     51.3      for vaski_data in tqdm(pd.read_csv(vaski_fname, sep="\t", chunksize=10000), total=31):  # Total achieved by experiment
    16        31    1019717.7  32894.1      0.9          vaski_data['doctype'] = vaski_data["XmlData"].str.extract(r"(VASKI_JULKVP_\w+)")
    17        31     302458.1   9756.7      0.3          vaski_data = vaski_data[vaski_data['doctype'].str.endswith('_fi')]
    18                                           
    19      1423      18644.5     13.1      0.0          for doctype in vaski_data['doctype'].unique():
    20      1392    3151755.2   2264.2      2.8              sub_vaski = vaski_data[vaski_data['doctype'] == doctype].drop(columns=["doctype"])
    21      1392      22631.5     16.3      0.0              f_path = os.path.join("data", "raw", "vaski", f"{doctype}.tsv")            
    22      1392      22584.9     16.2      0.0              if not os.path.exists(f_path):  # If no file, write header
    23        71    3027172.2  42636.2      2.7                  sub_vaski.to_csv(f_path, sep="\t", header=True, index=False)
    24                                                       else:  # If file, no header and append
    25      1321   46288838.0  35040.8     41.9                  sub_vaski.to_csv(f_path, sep="\t", header=False, index=False, mode='a')
```
180s -> 110s
helpot 60s pois, mut nyt pullonkaulana on pandasin csv luku ja kirjotus, oiskohan polars kiva

```
Wrote profile results to 'vaski_parser.py.lprof'
Timer unit: 1e-06 s

Total time: 6.87593 s
File: pipes/vaski_parser.py
Function: vaski_parser at line 10

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    10                                           @profile
    11                                           def vaski_parser():
    12         1         25.9     25.9      0.0      vaski_fname = os.path.join("data", "raw", "VaskiData.tsv")
    13                                           
    14        32    2035592.2  63612.3     29.6      for vaski_data in tqdm(pl.read_csv(vaski_fname, separator="\t", has_header=True).iter_slices(n_rows=10_000), total=31):  # Total achieved by experiment
    15        62     105718.6   1705.1      1.5          vaski_data = vaski_data.with_columns(
    16        31       2639.7     85.2      0.0              pl.col("XmlData").str.extract(r"VASKI_JULKVP_(\w+)").alias("doctype")
    17                                                   )
    18        31      23743.5    765.9      0.3          vaski_data = vaski_data.filter(pl.col("doctype").str.ends_with("_fi"))
    19                                           
    20      1423     298467.2    209.7      4.3          for (doctype,), sub_vaski in vaski_data.group_by("doctype"):
    21      1392      25493.5     18.3      0.4              f_path = os.path.join("data", "raw", "vaski", f"{doctype}.tsv")            
    22      1392     378903.9    272.2      5.5              sub_vaski = sub_vaski.drop("doctype")
    23      2784      78876.2     28.3      1.1              with open(f_path, mode="a" if os.path.exists(f_path) else "w") as f:
    24      1392    3926473.8   2820.7     57.1                  sub_vaski.write_csv(f, separator="\t", include_header=not os.path.exists(f_path))
```

110s -> 7s
nice, ilmast perffii

paha sanoo miks pandas on noi paljo hitaampi mut sitä en jaksanu alkaa selvittää, jätetään lukijalle tehtäväks