### PR TITLE
chore: pin postgres version to 18

### DIFF
--- a/.devcontainer/Dockerfile.postgres
+++ b/.devcontainer/Dockerfile.postgres
@@ -1,5 +1,5 @@
 # Dockerfile for custom Postgres image with built-in init scripts
-FROM postgres:latest
+FROM postgres:18.1
 
 # Copy initialization scripts into the image
 COPY postgres-init-scripts/ /docker-entrypoint-initdb.d/

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       dockerfile: .devcontainer/Dockerfile.postgres
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres


### PR DESCRIPTION
aiemmin toi postgres docker kontin tägi oli `latest` eli ku rebuildas devikontin ni se imasee ain mikä lie tuorein postgres, vissiin vastikää julkastu stabiiliks postgres 18 jossa muuttu miten sinne tulis mountata datakansio (`docker-compose.yml`), ja hommat hajos kuten versiopäivityksis tapana

nyt pakotetaan valitsemaan 18.1 versio possusta ja mountataan filut oikein sen kannalta, mut tää tarkottaa et sit ku seuraavan kerran rebuildaatte devikontin ni homma hajoo ellette käsin ekaks stoppaa possukonttii ja sen jälkee nukee sen datoja (ja sit `make nuke-database`)