### PR TITLE
feat: :sparkles: Add election funding and budgets to database

### DIFF
--- a/pipes/election_budgets_pipe.py
+++ b/pipes/election_budgets_pipe.py
@@ -1,0 +1,92 @@
+import os
+import polars as pl
+
+from db import get_connection
+
+raw_path = os.path.join("data", "raw", "election23_budgets.csv")
+csv_path = os.path.join("data", "preprocessed", "election_budgets.csv")
+
+def preprocess_data():
+
+    budgets_df = pl.read_csv(raw_path, infer_schema_length=10000, separator=";")
+
+    budgets_df = budgets_df.with_columns(
+                        pl.col("'Etunimet'").str.strip_chars("'").alias("first_name"),
+                        pl.col("'Sukunimi'").str.strip_chars("'").alias("last_name"),
+                        pl.col("'Ehdokkaan mahdollisen tukiryhman nimi'").str.strip_chars("'").alias("support_group"),
+                        pl.lit(2023).alias("election_year"),
+                        pl.col("'Vaalikampanjan kulut yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("expenses_total"),
+                        pl.col("'Vaalikampanjan rahoitus yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("incomes_total"),
+                        pl.col("'2.1 Rahoitus sisaltaa omia varoja yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_own"),
+                        pl.col("'2.2 Rahoitus sisaltaa ehdokkaan ja tukiryhman ottamia lainoja yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_loan"),
+                        pl.col("'2.3 Rahoitus sisaltaa yksityishenkiloilta saatua tukea yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_person"),
+                        pl.col("'2.4 Rahoitus sisaltaa yrityksilta saatua tukea yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_company"),
+                        pl.col("'2.5 Rahoitus sisaltaa puolueelta saatua tukea yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_party"),
+                        pl.col("'2.6 Rahoitus sisaltaa puolueyhdistyksilta saatua tukea yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_party_union"),
+                        pl.col("'2.8 Rahoitus sisaltaa valitettya tukea yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_forwarded"),
+                        pl.col("'2.7 Rahoitus sisaltaa muilta tahoilta saatua tukea yhteensa'").str.strip_chars("'").str.replace_all(r"\s", "").replace("", "0").str.replace(",", ".").cast(pl.Float32).alias("income_other"))
+    
+    # Drop original columns
+    budgets_df = budgets_df[:, -14:]
+    
+    # Fetch active mps
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    cursor.execute("""SELECT DISTINCT
+                        person_id,
+                        first_name,
+                        last_name
+                    FROM (public.mp_parliamentary_group_memberships
+                    INNER JOIN public.persons ON persons.id = person_id)
+                    WHERE end_date is null 
+                    ;""")
+
+    mp_df = pl.DataFrame(cursor.fetchall(), schema=["person_id", "first_name", "last_name"], orient="row")
+
+    cursor.close()
+    conn.close()
+
+    # Cast types to enable join
+    mp_df = mp_df.with_columns(
+                pl.col("first_name").cast(pl.Utf8),
+                pl.col("last_name").cast(pl.Utf8))
+
+    # Join to match mps to their ids
+    budgets_df = budgets_df.join(mp_df,
+                on=["first_name", "last_name"],
+                how="inner")
+    
+    # Drop useless mp name columns
+    budgets_df = budgets_df.drop(["first_name", "last_name"])
+
+    # Reorder
+    budgets_df = budgets_df.select([budgets_df.columns[-1], *budgets_df.columns[:-1]])
+
+    budgets_df.write_csv(csv_path)
+
+def import_data():
+    conn = get_connection()
+    cursor = conn.cursor()
+    
+    with open(csv_path) as f:
+        cursor.copy_expert("COPY election_budgets(person_id, support_group, election_year, expenses_total, incomes_total, income_own, income_loan, income_person, income_company, " \
+                        "income_party, income_party_union, income_forwarded, income_other) FROM stdin DELIMITERS ',' CSV HEADER QUOTE '\"';", f)
+    
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preprocess-data", help="preprocess the data", action="store_true")
+    parser.add_argument("--import-data", help="import preprocessed data", action="store_true")
+    args = parser.parse_args()
+    if args.preprocess_data:
+        preprocess_data()
+    if args.import_data:
+        import_data()
+    if not args.preprocess_data and not args.import_data:
+        preprocess_data()
+        import_data()

--- a/pipes/election_fundings_pipe.py
+++ b/pipes/election_fundings_pipe.py
@@ -1,0 +1,99 @@
+import os
+import polars as pl
+
+from db import get_connection
+
+raw_path = os.path.join("data", "raw", "election23_fundings.csv")
+csv_path = os.path.join("data", "preprocessed", "election_fundings.csv")
+
+# Map to translate the VTV codes to eduri database funding types
+funding_type_map = {
+                        "2.2": 'loan', 
+                        "2.3": 'person', 
+                        "2.4": 'company', 
+                        "2.5": 'party', 
+                        "2.6": 'party_union', 
+                        "2.7": 'other', 
+                        "2.8": 'forwarded'
+                    }
+
+def preprocess_data():
+
+    fundings_df = pl.read_csv(raw_path, infer_schema_length=10000, separator=";")
+
+    fundings_df = fundings_df.with_columns(pl.lit(2023).alias("election_year"),
+                         pl.col("'Tukilahteen lomakenumerot'").str.strip_chars("'").replace(funding_type_map).alias("ftype"),
+                         pl.col("'Tukija'").str.strip_chars("'").alias("funder_organization"),
+                         pl.col("'Tukijan y-tunnus/yhdistysrekisterinumero jos on'").str.strip_chars("'").alias("funder_company_id"),
+                         pl.col("'Tukijan etunimet'").str.strip_chars("'").alias("funder_first_name"),
+                         pl.col("'Tukijan sukunimi'").str.strip_chars("'").alias("funder_last_name"),
+                         pl.col("'Tuen saajan etunimet'").str.strip_chars("'").alias("first_name"),
+                         pl.col("'Tuen saajan Sukunimi'").str.strip_chars("'").alias("last_name"),
+                         pl.col("'Lainan nimi'").str.strip_chars("'").alias("loan_title"),
+                         pl.col("'Lainan takaisinmaksuaika/laina-aika'").str.strip_chars("'").alias("loan_schedule"),
+                         pl.col("'Tuen maara'").str.strip_chars("'").str.replace_all(r"\s", "").str.replace(",", ".").cast(pl.Float32).alias("amount"))
+    
+    # Drop original columns
+    fundings_df = fundings_df[:, -11:]
+    
+    # Fetch active mps
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    cursor.execute("""SELECT DISTINCT
+                        person_id,
+                        first_name,
+                        last_name
+                    FROM (public.mp_parliamentary_group_memberships
+                    INNER JOIN public.persons ON persons.id = person_id)
+                    WHERE end_date is null 
+                    ;""")
+
+    mp_df = pl.DataFrame(cursor.fetchall(), schema=["person_id", "first_name", "last_name"], orient="row")
+
+    cursor.close()
+    conn.close()
+
+    # Cast types to enable join
+    mp_df = mp_df.with_columns(
+                pl.col("first_name").cast(pl.Utf8),
+                pl.col("last_name").cast(pl.Utf8))
+
+    # Join to match mps to their ids
+    fundings_df = fundings_df.join(mp_df,
+                on=["first_name", "last_name"],
+                how="inner")
+    
+    # Drop useless mp name columns
+    fundings_df = fundings_df.drop(["first_name", "last_name"])
+
+    # Reorder
+    fundings_df = fundings_df.select([fundings_df.columns[-1], *fundings_df.columns[:-1]])
+
+    fundings_df.write_csv(csv_path)
+
+def import_data():
+    conn = get_connection()
+    cursor = conn.cursor()
+    
+    with open(csv_path) as f:
+        cursor.copy_expert("COPY election_fundings(person_id, election_year, ftype, funder_organization, funder_company_id, funder_first_name, " \
+                                        "funder_last_name, loan_title, loan_schedule, amount) FROM stdin DELIMITERS ',' CSV HEADER QUOTE '\"';", f)
+    
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preprocess-data", help="preprocess the data", action="store_true")
+    parser.add_argument("--import-data", help="import preprocessed data", action="store_true")
+    args = parser.parse_args()
+    if args.preprocess_data:
+        preprocess_data()
+    if args.import_data:
+        import_data()
+    if not args.preprocess_data and not args.import_data:
+        preprocess_data()
+        import_data()

--- a/postgres-init-scripts/01_create_tables.sql
+++ b/postgres-init-scripts/01_create_tables.sql
@@ -290,6 +290,47 @@ CREATE TABLE IF NOT EXISTS lobby_actions (
     contact_method VARCHAR(50)
 );
 
+DO $$ BEGIN  
+    CREATE TYPE funder_type AS ENUM ('loan', 'person', 'company', 'party', 'party_union', 'other', 'forwarded');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Election fundings
+-- From Valtiontalouden tarkastusvirasto
+CREATE TABLE IF NOT EXISTS election_fundings (
+    id SERIAL PRIMARY KEY,
+    person_id INT NOT NULL REFERENCES persons(id),
+    election_year INT NOT NULL,
+    ftype funder_type NOT NULL,
+    funder_organization VARCHAR(200),
+    funder_company_id VARCHAR(20),
+    funder_first_name VARCHAR(100),
+    funder_last_name VARCHAR(100),
+    loan_title VARCHAR(200),
+    loan_schedule VARCHAR(200),
+    amount REAL NOT NULL
+);
+
+-- Election budgets
+-- Election budgets From Valtiontalouden tarkastusvirasto
+CREATE TABLE IF NOT EXISTS election_budgets (
+    person_id INT NOT NULL REFERENCES persons(id),
+    support_group VARCHAR(200),     -- Candidates often have organizations specifically for their campaign
+    election_year INT NOT NULL,
+    expenses_total REAL NOT NULL,
+    incomes_total REAL NOT NULL,
+    income_own REAL NOT NULL,       -- Different types of incomes
+    income_loan REAL NOT NULL,
+    income_person REAL NOT NULL,
+    income_company REAL NOT NULL,
+    income_party REAL NOT NULL,
+    income_party_union REAL NOT NULL,
+    income_forwarded REAL NOT NULL,
+    income_other REAL NOT NULL,
+    PRIMARY KEY(person_id, election_year)
+);
+
 -- Promises
 -- Election promise from Yle Vaalikone
 CREATE TABLE IF NOT EXISTS promises (


### PR DESCRIPTION
Lisätään [VTV:n tietokannasta](https://www.vaalirahoitusvalvonta.fi/fi/index/vaalirahoitus/haetietoavaalirahoitusilmoituksista/tutkitietoaineistoja.html) (jonka data saatavilla "5–7 vuotta vaalituloksen vahvistamisesta") vaalirahoitukseen liittyvä data. 

- Budjettitaulussa on ehdokkaan mahdollinen tukiryhmä ja vaalikampanjan tulot ja menot. Tulot on jaettu luokkiin. Menoluokatkin löytyy VTV:n datasta, mutta niitä ei ainakaan toistaiseksi nyt lisätty, koska ne oli tyyliä televisio, tapahtumat jne.
- Rahoitustaulusta löytyy erikseen rahoittajat summineen ja tyyppeineen.


Mielenkiintoisia johdannaisia tästä datasta ainakin:
1. Top ehdokkaat ja puolueet
2. Top lahjoittajat
3. Ulkopuolisen rahan osuus vaalirahoituksesta
4. Kelle jäi kuinka paljon vaalirahaa käyttämättä eli tulot vs menot (esim Antti Häkkäsellä 30k)