### PR TITLE
Capture subheaders to proposal from xml

### DIFF
--- a/frontend/src/database.gen.d.ts
+++ b/frontend/src/database.gen.d.ts
@@ -5,373 +5,314 @@
 
 import type { ColumnType } from "kysely";
 
-export type Generated<T> =
-    T extends ColumnType<infer S, infer I, infer U>
-        ? ColumnType<S, I | undefined, U>
-        : ColumnType<T, T | undefined, T>;
-export type Generated<T> =
-    T extends ColumnType<infer S, infer I, infer U>
-        ? ColumnType<S, I | undefined, U>
-        : ColumnType<T, T | undefined, T>;
+export type FunderType = "company" | "forwarded" | "loan" | "other" | "party" | "party_union" | "person";
 
-export type ProposalStatus =
-    | "cancelled"
-    | "expired"
-    | "open"
-    | "handled"
-    | "passed"
-    | "passed_changed"
-    | "passed_urgent"
-    | "rejected"
-    | "resting";
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
 
-export type ProposalType =
-    | "citizen"
-    | "government"
-    | "mp_debate"
-    | "mp_law"
-    | "mp_petition";
-export type ProposalType =
-    | "citizen"
-    | "government"
-    | "mp_debate"
-    | "mp_law"
-    | "mp_petition";
+export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>;
+
+export type ProposalStatus = "cancelled" | "expired" | "handled" | "open" | "passed" | "passed_changed" | "passed_urgent" | "rejected" | "resting";
+
+export type ProposalType = "citizen" | "government" | "mp_debate" | "mp_law" | "mp_petition";
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export type Vote = "absent" | "abstain" | "no" | "yes";
 
+export interface Absences {
+  id: Generated<number>;
+  person_id: number;
+  record_assembly_code: string;
+  record_number: number;
+  record_year: number;
+  work_related: boolean | null;
+}
+
 export interface AgendaItems {
-    parliament_id: string;
-    record_assembly_code: string;
-    record_nro: number;
-    record_year: number;
-    title: string;
+  parliament_id: string;
+  record_assembly_code: string;
+  record_number: number;
+  record_year: number;
+  title: string;
 }
 
 export interface Assemblies {
-    code: string | null;
-    name: string;
+  code: string | null;
+  name: string;
 }
 
 export interface Ballots {
-    id: number;
-    minutes_url: string | null;
-    parliament_id: string | null;
-    results_url: string | null;
-    session_item_title: string | null;
-    start_time: Timestamp | null;
-    title: string | null;
-    id: number;
-    minutes_url: string | null;
-    parliament_id: string | null;
-    results_url: string | null;
-    session_item_title: string | null;
-    start_time: Timestamp | null;
-    title: string | null;
+  id: number;
+  minutes_url: string | null;
+  parliament_id: string | null;
+  results_url: string | null;
+  session_item_title: string | null;
+  start_time: Timestamp | null;
+  title: string | null;
 }
 
 export interface CommitteeBudgetReports {
-    committee_name: string;
-    id: string;
-    proposal_id: string;
-    committee_name: string;
-    id: string;
-    proposal_id: string;
+  committee_name: string;
+  id: string;
+  proposal_id: string;
 }
 
 export interface CommitteeReports {
-    committee_name: string;
-    date: Timestamp;
-    id: string;
-    law_changes: string | null;
-    opinion: string;
-    proposal_id: string;
-    proposal_summary: string;
-    reasoning: string | null;
-    committee_name: string;
-    date: Timestamp;
-    id: string;
-    law_changes: string | null;
-    opinion: string;
-    proposal_id: string;
-    proposal_summary: string;
-    reasoning: string | null;
+  committee_name: string;
+  date: Timestamp;
+  id: string;
+  law_changes: string | null;
+  opinion: string;
+  proposal_id: string;
+  proposal_summary: string;
+  reasoning: string | null;
 }
 
 export interface CommitteeReportSignatures {
-    committee_report_id: string;
-    person_id: number;
-    committee_report_id: string;
-    person_id: number;
+  committee_report_id: string;
+  person_id: number;
 }
 
-export interface Committees {
-    name: string;
-    name: string;
+export interface ElectionBudgets {
+  election_year: number;
+  expenses_total: number;
+  income_company: number;
+  income_forwarded: number;
+  income_loan: number;
+  income_other: number;
+  income_own: number;
+  income_party: number;
+  income_party_union: number;
+  income_person: number;
+  incomes_total: number;
+  person_id: number;
+  support_group: string | null;
+}
+
+export interface ElectionFundings {
+  amount: number;
+  election_year: number;
+  ftype: FunderType;
+  funder_company_id: string | null;
+  funder_first_name: string | null;
+  funder_last_name: string | null;
+  funder_organization: string | null;
+  id: Generated<number>;
+  loan_schedule: string | null;
+  loan_title: string | null;
+  person_id: number;
 }
 
 export interface ElectionSeasons {
-    end_year: Timestamp;
-    start_year: Timestamp;
-    end_year: Timestamp;
-    start_year: Timestamp;
+  end_date: Timestamp | null;
+  start_date: Timestamp;
 }
 
 export interface Interests {
-    category: string | null;
-    id: Generated<number>;
-    interest: string | null;
-    person_id: number | null;
-    category: string | null;
-    id: Generated<number>;
-    interest: string | null;
-    person_id: number | null;
+  category: string | null;
+  id: Generated<number>;
+  interest: string | null;
+  person_id: number | null;
 }
 
 export interface Lobbies {
-    id: string;
-    industry: string | null;
-    name: string;
+  id: string;
+  industry: string | null;
+  name: string;
 }
 
 export interface LobbyActions {
-    contact_method: string | null;
-    id: Generated<number>;
-    lobby_id: string;
-    person_id: number;
-    term_id: number;
-    topic_id: number;
+  contact_method: string | null;
+  id: Generated<number>;
+  lobby_id: string;
+  person_id: number;
+  term_id: number;
+  topic_id: number;
 }
 
 export interface LobbyTerms {
-    end_date: Timestamp | null;
-    id: number;
-    start_date: Timestamp | null;
+  end_date: Timestamp | null;
+  id: number;
+  start_date: Timestamp | null;
 }
 
 export interface LobbyTopics {
-    id: number;
-    project: string | null;
-    topic: string;
+  id: number;
+  project: string | null;
+  topic: string;
 }
 
 export interface MinisterPositions {
-    title: string;
-    title: string;
+  title: string;
 }
 
 export interface Ministers {
-    cabinet_id: string | null;
-    end_date: Timestamp | null;
-    minister_position: string;
-    person_id: number;
-    start_date: Timestamp;
-    cabinet_id: string | null;
-    end_date: Timestamp | null;
-    minister_position: string;
-    person_id: number;
-    start_date: Timestamp;
+  cabinet_id: string | null;
+  end_date: Timestamp | null;
+  minister_position: string;
+  person_id: number;
+  start_date: Timestamp;
 }
 
 export interface MpCommitteeMemberships {
-    committee_name: string;
-    end_date: Timestamp | null;
-    person_id: number;
-    role: string;
-    start_date: Timestamp;
-    committee_name: string;
-    end_date: Timestamp | null;
-    person_id: number;
-    role: string;
-    start_date: Timestamp;
+  committee_name: string;
+  end_date: Timestamp | null;
+  person_id: number;
+  role: string;
+  start_date: Timestamp;
 }
 
 export interface MpParliamentaryGroupMemberships {
-    end_date: Timestamp | null;
-    person_id: number;
-    pg_id: string;
-    start_date: Timestamp;
-    end_date: Timestamp | null;
-    person_id: number;
-    pg_id: string;
-    start_date: Timestamp;
+  end_date: Timestamp | null;
+  person_id: number;
+  pg_id: string;
+  start_date: Timestamp;
 }
 
 export interface Objections {
-    committee_report_id: string | null;
-    id: Generated<number>;
-    motion: string | null;
-    reasoning: string | null;
-    committee_report_id: string | null;
-    id: Generated<number>;
-    motion: string | null;
-    reasoning: string | null;
+  committee_report_id: string | null;
+  id: Generated<number>;
+  motion: string | null;
+  reasoning: string | null;
 }
 
 export interface ObjectionSignatures {
-    objection_id: Generated<number>;
-    person_id: number;
-    objection_id: Generated<number>;
-    person_id: number;
+  objection_id: Generated<number>;
+  person_id: number;
 }
 
 export interface ParliamentaryGroups {
-    id: string;
-    name: string | null;
-    id: string;
-    name: string | null;
+  id: string;
+  name: string | null;
 }
 
 export interface Persons {
-    email: string | null;
-    first_name: string | null;
-    full_name: string | null;
-    id: number;
-    last_name: string | null;
-    occupation: string | null;
-    phone_number: string | null;
-    photo: string | null;
-    place_of_birth: string | null;
-    place_of_residence: string | null;
-    year_of_birth: number | null;
-    email: string | null;
-    first_name: string | null;
-    full_name: string | null;
-    id: number;
-    last_name: string | null;
-    occupation: string | null;
-    phone_number: string | null;
-    photo: string | null;
-    place_of_birth: string | null;
-    place_of_residence: string | null;
-    year_of_birth: number | null;
+  email: string | null;
+  first_name: string | null;
+  full_name: string | null;
+  id: number;
+  last_name: string | null;
+  occupation: string | null;
+  phone_number: string | null;
+  photo: string | null;
+  place_of_birth: string | null;
+  place_of_residence: string | null;
+  search_vector: string | null;
+  year_of_birth: number | null;
 }
 
-export interface Proposals {
-    date: Timestamp;
-    id: string;
-    law_changes: string | null;
-    ptype: ProposalType | null;
-    reasoning: string | null;
-    status: ProposalStatus;
-    summary: string | null;
-    title: string | null;
+export interface PgModeVoteView {
+  ballot_id: number | null;
+  count: Int8 | null;
+  mode_vote: Vote | null;
+  pg_id: string | null;
 }
 
-export interface ProposalSignatures {
-    first: boolean | null;
-    person_id: number;
-    proposal_id: string;
-    first: boolean | null;
-    person_id: number;
-    proposal_id: string;
-}
-
-export interface Records {
-    assembly_code: string;
-    creation_date: Timestamp;
-    meeting_date: Timestamp;
-    nro: number;
-    year: number;
-}
-
-export interface Speeches {
-    agenda_item_parliament_id: string | null;
-    id: string;
-    person_id: number;
-    record_assembly_code: string | null;
-    record_nro: number | null;
-    record_year: number | null;
-    response_to: string | null;
-    speech: string;
-    speech_type: string;
-    start_time: Timestamp;
-}
-
-export interface Votes {
-    ballot_id: number;
-    person_id: number;
-    vote: Vote | null;
-    ballot_id: number;
-    person_id: number;
-    vote: Vote | null;
+export interface PgVoteCountView {
+  ballot_id: number | null;
+  count: Int8 | null;
+  pg_id: string | null;
+  vote: Vote | null;
 }
 
 export interface Promises {
-    id: Generated<number>;
-    person_id: number;
-    promise: string;
-    election_year: number;
+  election_year: number;
+  id: Generated<number>;
+  person_id: number;
+  promise: string;
 }
 
-export interface PGVoteCounts {
-    pg_id: string;
-    ballot_id: number;
-    vote: Vote;
-    count: number;
+export interface ProposalReasoning {
+  content: string | null;
+  position: number | null;
+  proposal_id: string | null;
+  title: string | null;
 }
 
-export interface PGModeVotes {
-    pg_id: string;
-    ballot_id: number;
-    mode_vote: Vote;
-    count: number;
+export interface Proposals {
+  date: Timestamp;
+  id: string;
+  law_changes: string | null;
+  ptype: ProposalType | null;
+  search_vector: string | null;
+  status: ProposalStatus;
+  summary: string | null;
+  title: string | null;
 }
 
-export interface ContraVoteScores {
-    person_id: number;
-    contra_vote_score: number;
+export interface ProposalSignatures {
+  first: boolean | null;
+  person_id: number;
+  proposal_id: string;
 }
 
-export interface PGVoteCounts {
-    pg_id: string;
-    ballot_id: number;
-    vote: Vote;
-    count: number;
+export interface Records {
+  assembly_code: string;
+  creation_date: Timestamp;
+  meeting_date: Timestamp;
+  number: number;
+  rollcall_id: string | null;
+  year: number;
 }
 
-export interface PGModeVotes {
-    pg_id: string;
-    ballot_id: number;
-    mode_vote: Vote;
-    count: number;
+export interface Speeches {
+  agenda_item_parliament_id: string | null;
+  id: string;
+  person_id: number;
+  record_assembly_code: string | null;
+  record_number: number | null;
+  record_year: number | null;
+  response_to: string | null;
+  speech: string;
+  speech_type: string;
+  start_time: Timestamp;
 }
 
-export interface ContraVoteScores {
-    person_id: number;
-    contra_vote_score: number;
+export interface Topics {
+  term: string | null;
+  topic_id: string;
+}
+
+export interface Votes {
+  ballot_id: number;
+  person_id: number;
+  vote: Vote | null;
 }
 
 export interface DB {
-    agenda_items: AgendaItems;
-    assemblies: Assemblies;
-    ballots: Ballots;
-    committee_budget_reports: CommitteeBudgetReports;
-    committee_report_signatures: CommitteeReportSignatures;
-    committee_reports: CommitteeReports;
-    election_seasons: ElectionSeasons;
-    interests: Interests;
-    lobbies: Lobbies;
-    lobby_actions: LobbyActions;
-    lobby_terms: LobbyTerms;
-    lobby_topics: LobbyTopics;
-    minister_positions: MinisterPositions;
-    ministers: Ministers;
-    mp_committee_memberships: MpCommitteeMemberships;
-    mp_parliamentary_group_memberships: MpParliamentaryGroupMemberships;
-    objection_signatures: ObjectionSignatures;
-    objections: Objections;
-    parliamentary_groups: ParliamentaryGroups;
-    persons: Persons;
-    proposal_signatures: ProposalSignatures;
-    proposals: Proposals;
-    records: Records;
-    speeches: Speeches;
-    votes: Votes;
-    promises: Promises;
-    pg_vote_view: PGVoteCounts;
-    pg_mode_vote_view: PGModeVotes;
-    contra_vote_scores_view: ContraVoteScores;
+  absences: Absences;
+  agenda_items: AgendaItems;
+  assemblies: Assemblies;
+  ballots: Ballots;
+  committee_budget_reports: CommitteeBudgetReports;
+  committee_report_signatures: CommitteeReportSignatures;
+  committee_reports: CommitteeReports;
+  election_budgets: ElectionBudgets;
+  election_fundings: ElectionFundings;
+  election_seasons: ElectionSeasons;
+  interests: Interests;
+  lobbies: Lobbies;
+  lobby_actions: LobbyActions;
+  lobby_terms: LobbyTerms;
+  lobby_topics: LobbyTopics;
+  minister_positions: MinisterPositions;
+  ministers: Ministers;
+  mp_committee_memberships: MpCommitteeMemberships;
+  mp_parliamentary_group_memberships: MpParliamentaryGroupMemberships;
+  objection_signatures: ObjectionSignatures;
+  objections: Objections;
+  parliamentary_groups: ParliamentaryGroups;
+  persons: Persons;
+  pg_mode_vote_view: PgModeVoteView;
+  pg_vote_count_view: PgVoteCountView;
+  promises: Promises;
+  proposal_reasoning: ProposalReasoning;
+  proposal_signatures: ProposalSignatures;
+  proposals: Proposals;
+  records: Records;
+  speeches: Speeches;
+  topics: Topics;
+  votes: Votes;
 }

--- a/frontend/src/pages/edustajat/[memberOfParliament]/aloitteet.astro
+++ b/frontend/src/pages/edustajat/[memberOfParliament]/aloitteet.astro
@@ -36,7 +36,6 @@ const proposals = await db
     .where("proposal_signatures.first", "is", true)
     .select([
         "proposals.title",
-        "proposals.reasoning",
         "proposals.summary",
         "proposals.id",
         "proposal_signatures.first",

--- a/frontend/src/pages/esitykset/[proposal].astro
+++ b/frontend/src/pages/esitykset/[proposal].astro
@@ -1,7 +1,6 @@
 ---
 // We inject markdown in multiple places in this file, it is safe trust me bro
 /* eslint-disable astro/no-set-html-directive */
-import type { NotNull } from "kysely";
 import { db } from "~src/database";
 import { marked } from "marked";
 import MpRoundPhotoList from "~src/components/MpRoundPhotoList.astro";
@@ -18,6 +17,13 @@ export async function getStaticPaths() {
 }
 
 const { proposal } = Astro.props;
+
+const proposal_reasonings = await db
+    .selectFrom("proposal_reasoning as pr")
+    .select(["pr.title", "pr.content"])
+    .where("pr.proposal_id", "=", proposal.id)
+    .orderBy("position")
+    .execute();
 
 const ballots = await db
     .selectFrom("ballots")
@@ -49,10 +55,17 @@ type Ballot = typeof ballots;
                 )
             }
             {
-                proposal.reasoning && (
+                proposal_reasonings && (
                     <li>
                         <a href="#reasoning">Perustelut</a>
                     </li>
+                    <ul>
+                        {proposal_reasonings.map((pr) => (
+                            <li>
+                                <a href={`#${pr.title}`}>{pr.title}</a>
+                            </li>
+                        ))}
+                    </ul>
                 )
             }
             {
@@ -84,11 +97,16 @@ type Ballot = typeof ballots;
         }
 
         {
-            proposal.reasoning && (
+            proposal_reasonings && (
                 <>
                     <h2 id="reasoning">Perustelut</h2>
-                    <Fragment set:html={marked(proposal.reasoning)} />
-                    <a href="#top">Ylös</a>
+                    { proposal_reasonings.map(
+                        (pr) => (
+                            <h1 id={`${pr.title}`}>{pr.title}</h1>
+                            <Fragment set:html={pr.content && marked(pr.content)} />
+                            <a href="#top">Ylös</a>)
+                        )
+                    }
                 </>
             )
         }

--- a/frontend/src/pages/esitykset/_utils.ts
+++ b/frontend/src/pages/esitykset/_utils.ts
@@ -16,7 +16,6 @@ export function proposalData() {
             "p.ptype as proposer",
             "p.status as status",
             "p.summary as summary",
-            "p.reasoning as reasoning",
             "p.law_changes as law_changes",
             "p.date as date",
             sql<Signature[]>`(

--- a/pipes/XML_parsing_help_functions.py
+++ b/pipes/XML_parsing_help_functions.py
@@ -150,6 +150,41 @@ def Perustelu_parse(root, NS, not_child_of=""):
 
     return reasoning
 
+def parse_reasoning_chapters(root, NS, proposal_id, not_child_of=""):
+    if not_child_of:
+        filter = f"[not(ancestor::{not_child_of})]"
+    else:
+        filter = ""
+
+    reasoning_nodes = root.xpath(
+            f".//asi:PerusteluOsa{filter}//sis1:OtsikkoTeksti | "
+            f".//asi:PerusteluOsa{filter}//sis1:ValiotsikkoTeksti | "
+            f".//asi:PerusteluOsa{filter}//sis:KappaleKooste[not(ancestor::tau:table)] | "
+            f".//asi:PerusteluOsa{filter}//tau:table | "
+            f".//asi:PerusteluOsa{filter}//sis:SisennettyKappaleKooste[not(ancestor::tau:table)]",
+            namespaces=NS
+        )
+    pos = 0
+    output = []
+    reasoning = None
+    for node in reasoning_nodes:
+        if "OtsikkoTeksti" in node.tag:
+            if reasoning is not None:
+                if reasoning['title'] != "" and reasoning['content'] != "":
+                    output.append(reasoning)
+                    pos += 1
+            reasoning = {
+                'proposal_id': proposal_id,
+                'title': node.text,
+                'position': pos,
+                'content': ''
+            }
+        else:
+            reasoning['content'] += "\n\n" + _txt(node)
+    output.append(reasoning)
+
+    return output
+
 def date_parse(root, NS):
 
     metadata = root.find(".//jme:JulkaisuMetatieto", namespaces=NS)

--- a/postgres-init-scripts/01_create_tables.sql
+++ b/postgres-init-scripts/01_create_tables.sql
@@ -186,9 +186,15 @@ CREATE TABLE IF NOT EXISTS proposals (
     date DATE NOT NULL,
     title VARCHAR(1000),
     summary TEXT,
-    reasoning TEXT,
     law_changes TEXT,
     status proposal_status NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS proposal_reasoning (
+    proposal_id VARCHAR(20) REFERENCES proposals(id),
+    title TEXT,
+    content TEXT,
+    position INT
 );
 
 -- Proposal signatures (esitysten allekirjoitukset)


### PR DESCRIPTION
closes #184 

Esityksien XML:ssä on rakennem että nodessa on tag jonka mukaan voidaan erotella otsikot ja tekstikappaleet. Jotta tää saadaan siirtymään myös meidän sovelluksen puolelle, luodaan uusi tietorakenne välittämään tekstikappaleita. Entinen kenttä proposal.reasoning poistuu, ja sen funktion korvaa taulu proposal_reasonings, missä proposal_idn mukaan yhdistetään tekstikappaleet, ja niiden järjestys säilyy position-kentän mukaan. Jokaisessa reasonings-entryssä on title ja/tai content jotka voidaan parsia eri tageilla htmlssä. Tää vähän mutkistaa tietokantarakennetta, mutta näyttää toimivan hyvin, ja sain myös otsikoitua linkkien kera noi eri alaotsikot.