### PR TITLE
feat: update markdown parsers

### DIFF
--- a/pipes/XML_parsing_help_functions.py
+++ b/pipes/XML_parsing_help_functions.py
@@ -2,7 +2,24 @@ import pandas as pd
 from lxml import etree
 from io import StringIO
 from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
 from xml.dom import minidom
+
+
+def prettify(elem):
+    """Return a pretty-printed XML string for the Element."""
+    rough_string = ElementTree.tostring(elem, "utf-8")
+    reparsed = minidom.parseString(rough_string)
+    return reparsed.toprettyxml(indent="  ")
+
+
+def pp(elem):
+    print(prettify(elem))
+
+
+class ParserError(Exception):
+    """Custom error for handling parser edge cases"""
+
 
 NS = {
     "asi": "http://www.vn.fi/skeemat/asiakirjakooste/2010/04/27",
@@ -35,6 +52,8 @@ NS = {
     "def": "http://www.eduskunta.fi/skeemat/siirtokooste/2011/05/17",
     "eka": "http://www.eduskunta.fi/skeemat/eduskuntaaloite/2012/08/10",
     "ptk": "http://www.eduskunta.fi/skeemat/poytakirja/2011/01/28",
+    "ns1": "http://www.vn.fi/skeemat/sisaltoelementit/2010/04/27",
+    "ns2": "http://www.vn.fi/skeemat/sisaltoelementit/2010/04/27",
 }
 
 
@@ -142,32 +161,297 @@ def tau_to_md(root):
     return "\n\n".join(dfs)
 
 
-def Perustelu_parse(root, NS, not_child_of=""):
-    if not_child_of:
-        filter = f"[not(ancestor::{not_child_of})]"
+def get_tag_type(element: Element) -> str:
+    """
+    For an element, returns the tag type without namespace, for example
+
+    `'{http://www.vn.fi/skeemat/sisaltoelementit/2010/04/27}OtsikkoTeksti'`
+    =>
+    `'OtsikkoTeksti'`
+    """
+    return element.tag.split("}")[1]
+
+
+def OtsikkoTeksti_parse(element: Element, level: int):
+    """Parses an <OtsikkoTeksti> into a heading of the appropriate level"""
+    if level < 1 or level > 6:
+        raise ParserError(f"Heading level can't be {level}!")
+    if element.text is None:
+        return ""  # broken otsikkoteksti node
+    return f"{'#' * level} {element.text.capitalize()}\n\n"
+
+
+def KursiiviTeksti_parse(element: Element):
+    """Parses <KursiiviTeksti> inline element to italics"""
+    return f"*{element.text.strip()}* "
+
+
+def LihavaTeksti_parse(element: Element):
+    """Parses <LihavaTeksti> inline element to bold"""
+    return f"**{element.text.strip()}** "
+
+
+def LihavaKursiiviTeksti_parse(element: Element):
+    """Parses <LihavaKursiiviTeksti> inline element to bold italics"""
+    return f"***{element.text.strip()}*** "
+
+
+def KappaleKooste_parse(element: Element):
+    """
+    The main XML parsing function, handling all of the different leaf nodes of
+    the XML tree.
+    """
+
+    def _iter_kappale_content(elem: Element):
+        if elem.text:
+            yield ("text", elem.text)
+        for child in elem:
+            yield ("element", child)
+            if child.tail:
+                yield ("text", child.tail)
+
+    out = ""
+    citations = []
+    for type, value in _iter_kappale_content(element):
+        match type:
+            case "text":
+                out += value
+            case "element":
+                match get_tag_type(value):
+                    case (
+                        "KursiiviTeksti"
+                        | "HarvaKursiiviTeksti"
+                        | "LihavaTeksti"
+                        | "LihavaKursiiviTeksti"
+                    ) if value.text is None:
+                        continue  # sometimes there just isn't any content
+                    case "KursiiviTeksti" | "HarvaKursiiviTeksti":
+                        out += KursiiviTeksti_parse(value)
+                    case "LihavaTeksti":
+                        out += LihavaTeksti_parse(value)
+                    case "LihavaKursiiviTeksti":
+                        out += LihavaKursiiviTeksti_parse(value)
+
+                    case "YlaindeksiTeksti" if value.text is None:
+                        pass  # Some documents have empty XML nodes like this
+                    case "YlaindeksiTeksti" if value.text.strip() == "2":
+                        out += "²"
+                    case "YlaindeksiTeksti" if value.text.strip() == "3":
+                        out += "³"
+                    case "YlaindeksiTeksti":
+                        out += f"<sup>{value.text}</sup>"
+                    case "AlaindeksiTeksti" if value.text.strip() == "1":
+                        out += "₁"
+                    case "AlaindeksiTeksti" if value.text.strip() == "2":
+                        out += "₂"
+                    case "AlaindeksiTeksti" if value.text.strip() == "3":
+                        out += "₃"
+                    case "AlaindeksiTeksti" if value.text.strip() == "10":
+                        out += "₁₀"  # for example "PM10"
+                    case "AlaindeksiTeksti":
+                        out += f"<sub>{value.text}</sub>"
+                    case "AlaviiteTeksti":
+                        out += f"[^{id(value.text)}]"
+                        citations.append(f"[^{id(value.text)}]: {value.text}")
+                    case "YleinenViite":
+                        out += f"[{value[0].text}]({value.get(f'{{{NS["ns1"]}}}viiteURL')})"
+                    case "AlaviiteKooste":
+                        out += f"({KappaleKooste_parse(value).strip()})"
+                    case "Rivivaihto":
+                        # TODO: this is not a good solution, the documents look like there
+                        # would be a better way to parse these than to force a line break
+                        out += "  \n"
+                    case "Aukko":
+                        # TODO: might be unnecessary? extra whitespace isn't too bad, though
+                        out += " "
+                    case (
+                        "SaadoskokoelmaViiteTunnus"
+                        | "AsiakirjaViiteTunnus"
+                        | "SopimussarjaViiteTunnus"
+                    ):
+                        # No special meaning (yet)
+                        # TODO: we could use these to add hyperlinks to the related documents
+                        out += value.text
+
+                    case unknown:
+                        raise ParserError(f"Unknown tag: {unknown}", value.text, value)
+
+    if len(citations) > 0:
+        return out + "\n\n" + "\n\n".join(citations) + "\n\n"
     else:
-        filter = ""
+        return out + "\n\n"
 
-    reasoning_nodes = root.xpath(
-        f".//asi:PerusteluOsa{filter}//sis1:OtsikkoTeksti | "
-        f".//asi:PerusteluOsa{filter}//sis1:ValiotsikkoTeksti | "
-        f".//asi:PerusteluOsa{filter}//sis:KappaleKooste[not(ancestor::tau:table)] | "
-        f".//asi:PerusteluOsa{filter}//tau:table | "
-        f".//asi:PerusteluOsa{filter}//sis:SisennettyKappaleKooste[not(ancestor::tau:table)]",
-        namespaces=NS,
-    )
-    reasoning = "\n\n".join(
-        [
-            ("## " + _txt(n))
-            if ("OtsikkoTeksti" in n.tag)
-            else ("### " + _txt(n))
-            if ("ValiotsikkoTeksti" in n.tag)
-            else _txt(n)
-            for n in reasoning_nodes
-        ]
-    )
 
-    return reasoning
+def Kuva_parse(element: Element):
+    """
+    Parses a <Kuva> element. This will assume that the image asset exists
+    in the same relative path as whatever document holding it.
+    """
+    if len(element) == 0:
+        return ""  # broken image node
+    url = element[0].get(f"{{{NS['ns1']}}}kuvaTiedostoTeksti")
+    return f"![]({url})\n\n"
+
+
+def Lista_parse(element: Element):
+    """
+    Parses an XML <Lista> element to markdown, normalizing different list
+    bullet styles to just ordered or unordered markdown list items.
+    """
+    match element.get(f"{{{NS['ns2']}}}ulkoasuKoodi"):
+        case "Viiva" | "Tasaviiva" | "LyhytTasaviiva":
+            return (
+                "".join(f"- {KappaleKooste_parse(item[0])}\n" for item in element)
+                + "\n\n"
+            )
+        case "Numerosulku" | "Numeropiste":
+            return (
+                "".join(
+                    f"{idx + 1}. {KappaleKooste_parse(item[0])}\n"
+                    for idx, item in enumerate(element)
+                )
+                + "\n\n"
+            )
+        case "Tyhja":  # most likely a table of contents that can be skipped
+            return ""
+        case unknown:
+            raise ParserError(f"Unknown list type: {unknown}", element)
+
+
+def SuppeaLista_parse(element: Element):
+    """
+    Parses an XML <SuppeaLista> element to markdown.
+    This differs from <Lista> in that each list item is wrapped in its own
+    <SuppeaLista>, e.g.:
+
+    ```xml
+    <Lista>
+        <Alkio>dataa 1</Alkio>
+        <Alkio>dataa 2</Alkio>
+    </Lista>
+    ```
+    vs
+    ```xml
+    <SuppeaLista>
+        <Alkio>dataa 1</Alkio>
+    </SuppeaLista>
+    <SuppeaLista>
+        <Alkio>dataa 2</Alkio>
+    </SuppeaLista>
+
+    The reason for this distinction to ever exist is left as an exercise for the reader.
+    ```
+    """
+    out = ""
+    match element.get(f"{{{NS['ns2']}}}ulkoasuKoodi"):
+        case (
+            "Numeropiste"
+            | "JatkuvaNumeropiste"
+            | "JatkuvaNumerosulku"
+            | "Numerosulku"
+            | "Kirjainsulku"
+        ):
+            out = "".join(
+                f"{idx + 1}. {KappaleKooste_parse(child)}\n"
+                for idx, child in enumerate(element)
+            )
+        case "Viiva" | "Tasaviiva" | "LyhytViiva" | "LyhytTasaviiva":
+            out = "".join(f"- {KappaleKooste_parse(child)}\n" for child in element)
+        case unknown:
+            raise ParserError(f"Unknown shallow list type: {unknown}", element)
+    next_element = element.getnext()
+    next_element_tag = get_tag_type(next_element) if next_element is not None else None
+    if next_element_tag != "SuppeaLista":
+        out += "\n"
+    return out
+
+
+def xml_to_markdown(element: Element, level: int = 1):
+    """
+    Generic Vaski XML parser aiming to handle all text formatting cases and nested
+    heading levels via recursion.
+    """
+    match get_tag_type(element):
+        # parse actual contents
+        case (
+            "OtsikkoTeksti"
+            | "ValiotsikkoTeksti"
+            | "LihavaKursiiviOtsikkoTeksti"
+            | "RiviotsikkoTeksti"
+        ):
+            return OtsikkoTeksti_parse(element, level)
+        case "KappaleKooste" | "JohdantoTeksti" | "ViiteTeksti":
+            return KappaleKooste_parse(element)
+        case "SisennettyKappaleKooste":
+            return f"> {KappaleKooste_parse(element)}"
+        case "table":
+            return tau_to_md(element)
+        case "Kuva":
+            return Kuva_parse(element)
+        case "Lista":
+            return Lista_parse(element)
+        case "SuppeaLista":
+            return SuppeaLista_parse(element)
+
+        # skip these tags and recurse deeper
+        case (
+            "LukuOtsikko"
+            | "PerusteluOsa"
+            | "SisaltoKuvaus"
+            | "AsiaKuvaus"
+            | "PaatosOsa"
+            | "PaatosToimenpide"
+            | "PonsiOsa"
+            | "PykalaViite"
+        ):
+            return "".join(xml_to_markdown(el, level) for el in element)
+        # this denotes a subchapter so we increment level and recurse
+        case "PerusteluLuku" | "VireilletuloAsia":
+            return "".join(xml_to_markdown(el, level + 1) for el in element)
+
+        # these tags have no contents or we dont care about them, end this tail of recursion
+        case (
+            "OtsikkoNroTeksti"
+            | "Tyhja"
+            | "NeljannesTyhja"
+            | "AsiantuntijatToimenpide"
+            | "Valiokuntakasittely"
+            | "MuuAsiaKuvaus"
+            | "YhdistettyAsia"
+        ):  # committee reports pipe
+            return ""
+
+        case unknown_tag:
+            raise ParserError(f"Unknown tag: {unknown_tag}", element)
+
+
+def PerusteluOsa_parse_to_markdown(root: Element, NS):
+    """Finds and recursively parses `PerusteluOsa` from a root xml node"""
+    reasoning_part = root.find(".//asi:PerusteluOsa", namespaces=NS)
+    if reasoning_part is None:
+        return None
+    return xml_to_markdown(reasoning_part)
+
+
+def AsiaSisaltoKuvaus_parse_to_markdown(root: Element, NS):
+    """Finds all `AsiaKuvaus` and `SisaltoKuvaus` nodes and parses them to markdown"""
+    # TODO: are all of these relevant?
+    summary_parts = root.xpath(
+        ".//vsk:AsiaKuvaus | .//asi:SisaltoKuvaus | .//asi:AsiaKuvaus", namespaces=NS
+    )
+    return "\n\n".join(xml_to_markdown(part) for part in summary_parts)
+
+
+def PaatosOsa_parse_to_markdown(root: Element, NS):
+    """Finds and recursively parses `PaatosOsa` from a root xml node"""
+    opinion_parts = root.xpath(".//vsk:PaatosOsa | .//asi:PaatosOsa", namespaces=NS)
+    return "\n\n".join(xml_to_markdown(part) for part in opinion_parts)
+
+
+def Ponsi_parse_to_markdown(root: Element, NS):
+    """Finds and recursively parses `Ponsi` from a root xml node"""
+    ponsi_part = root.find(".//asi:PonsiOsa", namespaces=NS)
+    return xml_to_markdown(ponsi_part)
 
 
 def date_parse(root, NS):
@@ -182,40 +466,6 @@ def Nimeke_parse(root, NS):
     title = "\n\n".join([_txt(n) for n in title_nodes])
 
     return title
-
-
-def AsiaSisaltoKuvaus_parse(root, NS, not_child_of=""):
-    if not_child_of:
-        filter = f"[not(ancestor::{not_child_of})]"
-    else:
-        filter = ""
-
-    summary_nodes = root.xpath(
-        f".//vsk:AsiaKuvaus//sis:KappaleKooste[not(ancestor::tau:table)]{filter} | "
-        f".//asi:SisaltoKuvaus//sis:KappaleKooste[not(ancestor::tau:table)]{filter} | "
-        f".//asi:AsiaKuvaus//tau:table | "
-        f".//asi:SisaltoKuvaus//tau:table",
-        namespaces=NS,
-    )
-    summary = "\n\n".join([_txt(n) for n in summary_nodes])
-
-    return summary
-
-
-def Ponsi_parse(root, NS):
-    ponsi_nodes = root.xpath(
-        ".//asi:PonsiOsa//sis1:OtsikkoTeksti | "
-        ".//asi:PonsiOsa//asi1:JohdantoTeksti | "
-        ".//asi:PonsiOsa//sis:KappaleKooste[not(ancestor::tau:table)] | "
-        ".//asi:PonsiOsa//sis:SisennettyKappaleKooste[not(ancestor::tau:table)] |"
-        ".//asi:PonsiOsa//sis1:KappaleKooste[not(ancestor::tau:table)] |"
-        ".//asi:PonsiOsa//sis1:SisennettyKappaleKooste[not(ancestor::tau:table)] |"
-        ".//asi:PonsiOsa//tau:table",
-        namespaces=NS,
-    )
-    ponsi = "\n\n".join([_txt(n) for n in ponsi_nodes])
-
-    return ponsi
 
 
 def Saados_parse(root, NS):
@@ -290,25 +540,6 @@ def absentee_parse(root):
         absentees.append({"person_id": person_id, "work_related": work_related})
 
     return absentees
-
-
-def Paatos_parse(root, NS, not_child_of=""):
-    if not_child_of:
-        filter = f"[not(ancestor::{not_child_of})]"
-    else:
-        filter = ""
-
-    op_nodes = root.xpath(
-        f".//vsk:PaatosOsa//sis1:OtsikkoTeksti{filter} | "
-        f".//vsk:PaatosOsa//asi1:JohdantoTeksti{filter} | "
-        f".//vsk:PaatosOsa//sis:KappaleKooste[not(ancestor::tau:table)]{filter} | "
-        f".//vsk:PaatosOsa//sis:SisennettyKappaleKooste[not(ancestor::tau:table)]{filter} |"
-        f".//asi:PaatosOsa//tau:table",
-        namespaces=NS,
-    )
-    opinion = "\n\n".join([_txt(n) for n in op_nodes])
-
-    return opinion
 
 
 def Allekirjoittaja_parse(root, NS, eid, cursor=None):
@@ -387,10 +618,3 @@ def id_parse(root, NS):
     eid = metadata.get(f"{{{NS['met1']}}}eduskuntaTunnus", "").strip()
 
     return eid
-
-
-def prettify(elem):
-    """Return a pretty-printed XML string for the Element."""
-    rough_string = ElementTree.tostring(elem, "utf-8")
-    reparsed = minidom.parseString(rough_string)
-    return reparsed.toprettyxml(indent="  ")

--- a/pipes/committee_reports_pipe.py
+++ b/pipes/committee_reports_pipe.py
@@ -4,14 +4,14 @@ import pandas as pd
 from lxml import etree
 from io import StringIO
 from XML_parsing_help_functions import (
+    AsiaSisaltoKuvaus_parse_to_markdown,
+    PaatosOsa_parse_to_markdown,
+    PerusteluOsa_parse_to_markdown,
+    Ponsi_parse_to_markdown,
     _txt,
     id_parse,
     date_parse,
-    AsiaSisaltoKuvaus_parse,
-    Perustelu_parse,
-    Ponsi_parse,
     Saados_parse,
-    Paatos_parse,
     Osallistuja_parse,
     NS,
 )
@@ -76,15 +76,13 @@ def preprocess_data():
 
         # --- proposal_summary (restrict to content NOT under objections) ---
         # Using XPath to exclude any descendants that live inside vas:JasenMielipideOsa
-        proposal_summary = AsiaSisaltoKuvaus_parse(
-            mietinto, NS, not_child_of="vas:JasenMielipideOsa"
-        )
+        proposal_summary = AsiaSisaltoKuvaus_parse_to_markdown(mietinto, NS)
 
         # --- opinion (vsk:PaatosOsa), excluding any objection subtrees ---
-        opinion = Paatos_parse(root, NS, not_child_of="vas:JasenMielipideOsa")
+        opinion = PaatosOsa_parse_to_markdown(root, NS)
 
         # --- report-level reasoning (exclude objection reasoning) ---
-        reasoning = Perustelu_parse(mietinto, NS, not_child_of="vas:JasenMielipideOsa")
+        reasoning = PerusteluOsa_parse_to_markdown(mietinto, NS)
 
         # --- law changes (saa:SaadosOsa -> Markdown) ---
         law_changes = Saados_parse(root, NS)
@@ -98,10 +96,10 @@ def preprocess_data():
             obj_idx += 1  # 1-based index per report
 
             # Reasoning = asi:PerusteluOsa -> headers + paragraphs (both sis: and sis1:)
-            obj_reasoning = Perustelu_parse(objection, NS)
+            obj_reasoning = PerusteluOsa_parse_to_markdown(objection, NS)
 
             # Motion = asi:PonsiOsa -> johdanto + paragraphs (both sis: and sis1:)
-            obj_motion = Ponsi_parse(objection, NS)
+            obj_motion = Ponsi_parse_to_markdown(objection, NS)
 
             objection_records.append(
                 {

--- a/pipes/government_proposals_pipe.py
+++ b/pipes/government_proposals_pipe.py
@@ -3,11 +3,11 @@ import pandas as pd
 from lxml import etree
 from io import StringIO
 from XML_parsing_help_functions import (
+    AsiaSisaltoKuvaus_parse_to_markdown,
+    PerusteluOsa_parse_to_markdown,
     id_parse,
     date_parse,
     Nimeke_parse,
-    AsiaSisaltoKuvaus_parse,
-    Perustelu_parse,
     Saados_parse,
     status_parse,
     Allekirjoittaja_parse,
@@ -62,10 +62,10 @@ def preprocess_data():
         title = Nimeke_parse(proposal, NS)
 
         # SUMMARY
-        summary = AsiaSisaltoKuvaus_parse(proposal, NS)
+        summary = AsiaSisaltoKuvaus_parse_to_markdown(proposal, NS)
 
         # REASONING
-        reasoning = Perustelu_parse(proposal, NS)
+        reasoning = PerusteluOsa_parse_to_markdown(proposal, NS)
 
         # LAW_CHANGES
         law_changes = Saados_parse(proposal, NS)

--- a/pipes/interpellations_pipe.py
+++ b/pipes/interpellations_pipe.py
@@ -3,11 +3,11 @@ import pandas as pd
 from lxml import etree
 from io import StringIO
 from XML_parsing_help_functions import (
+    PerusteluOsa_parse_to_markdown,
+    Ponsi_parse_to_markdown,
     id_parse,
     date_parse,
     Nimeke_parse,
-    Perustelu_parse,
-    Ponsi_parse,
     status_parse,
     Allekirjoittaja_parse,
     NS,
@@ -66,8 +66,8 @@ def preprocess_data():
                 "id": eid.lower(),
                 "date": date_parse(interpellation_root, NS),
                 "title": Nimeke_parse(interpellation, NS),
-                "reasoning": Perustelu_parse(interpellation, NS),
-                "motion": Ponsi_parse(interpellation, NS),
+                "reasoning": PerusteluOsa_parse_to_markdown(interpellation, NS),
+                "motion": Ponsi_parse_to_markdown(interpellation, NS),
                 "status": status_parse(handling_root, handling_xml_str, NS),
             }
         )

--- a/pipes/mp_law_proposals_pipe.py
+++ b/pipes/mp_law_proposals_pipe.py
@@ -3,11 +3,11 @@ import pandas as pd
 from lxml import etree
 from io import StringIO
 from XML_parsing_help_functions import (
+    AsiaSisaltoKuvaus_parse_to_markdown,
+    PerusteluOsa_parse_to_markdown,
     id_parse,
     date_parse,
     Nimeke_parse,
-    AsiaSisaltoKuvaus_parse,
-    Perustelu_parse,
     Saados_parse,
     status_parse,
     Allekirjoittaja_parse,
@@ -72,8 +72,8 @@ def preprocess_data():
                 "ptype": "mp_law",
                 "date": date,
                 "title": Nimeke_parse(proposal, NS),
-                "summary": AsiaSisaltoKuvaus_parse(proposal, NS),
-                "reasoning": Perustelu_parse(proposal, NS),
+                "summary": AsiaSisaltoKuvaus_parse_to_markdown(proposal, NS),
+                "reasoning": PerusteluOsa_parse_to_markdown(proposal, NS),
                 "law_changes": Saados_parse(proposal, NS),
                 "status": status_parse(handling_root, handling_xml_str, NS),
             }

--- a/pipes/mp_petition_proposals_pipe.py
+++ b/pipes/mp_petition_proposals_pipe.py
@@ -3,11 +3,11 @@ import pandas as pd
 from lxml import etree
 from io import StringIO
 from XML_parsing_help_functions import (
+    AsiaSisaltoKuvaus_parse_to_markdown,
+    PerusteluOsa_parse_to_markdown,
     id_parse,
     date_parse,
     Nimeke_parse,
-    AsiaSisaltoKuvaus_parse,
-    Perustelu_parse,
     Saados_parse,
     Allekirjoittaja_parse,
     NS,
@@ -73,8 +73,8 @@ def preprocess_data():
                 "ptype": "mp_petition",
                 "date": date,
                 "title": Nimeke_parse(proposal, NS),
-                "summary": AsiaSisaltoKuvaus_parse(proposal, NS),
-                "reasoning": Perustelu_parse(proposal, NS),
+                "summary": AsiaSisaltoKuvaus_parse_to_markdown(proposal, NS),
+                "reasoning": PerusteluOsa_parse_to_markdown(proposal, NS),
                 "law_changes": Saados_parse(proposal, NS),
                 "status": status,
             }


### PR DESCRIPTION
nyt on vähä robustimpaa XMLän parsintaa markdowniks niin, et pidetään tallessa

- otsikkotasot
- muotoilut (bold, italic)
- listat
- linkit

ja ehkä vähä jotai muutaki. en kauhee montaa dokumenttii testannu, ni voi olla jotai mikä ontuu viel, mut näil pääsee ehk eteenpäi. 100% luomu artesaani ei sekoälyliejua