### PR TITLE
fix: proposal heading levels

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "pg": "^8.16.0",
         "rehype": "^13.0.2",
         "rehype-autolink-headings": "^7.1.0",
+        "rehype-shift-heading": "^2.0.0",
         "rehype-slug": "^6.0.0",
         "rehype-toc": "^3.0.2"
       },
@@ -4630,6 +4631,21 @@
         "vfile": "^6.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-shift-heading": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-shift-heading/-/hast-util-shift-heading-4.0.0.tgz",
+      "integrity": "sha512-1WzYRfcydfUIAn/N/QBDLlaG/JlXnE3Tx2ybuQFZKP4ZfM9v8FPJ/8i6pEaSoEtEI+FzjYmALlOJROkgRg3epg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -21210,6 +21226,20 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-shift-heading": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-shift-heading/-/rehype-shift-heading-2.0.0.tgz",
+      "integrity": "sha512-ykIgOpIop4Telm+JXv0yDaN8jeMSBE9jwcEOxQJrlSnC15OVFq4/jS/X3MC6zjhfGYAUyvMcYSY0eORne/gX5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-shift-heading": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "pg": "^8.16.0",
     "rehype": "^13.0.2",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-shift-heading": "^2.0.0",
     "rehype-slug": "^6.0.0",
     "rehype-toc": "^3.0.2"
   },

--- a/frontend/src/pages/esitykset/[proposal].astro
+++ b/frontend/src/pages/esitykset/[proposal].astro
@@ -2,7 +2,6 @@
 /* eslint-disable astro/no-set-html-directive */
 // We inject markdown in multiple places in this file, it is safe trust me bro
 
-import type { NotNull } from "kysely";
 import { db } from "~src/database";
 import { marked } from "marked";
 import MpRoundPhotoList from "~src/components/MpRoundPhotoList.astro";
@@ -11,6 +10,7 @@ import { proposalData, urlencodeProposalId } from "~src/pages/esitykset/_utils";
 import { PARLIAMENT_BASE_URL } from "~src/utils";
 import { rehype } from "rehype";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypeShiftHeading from "rehype-shift-heading";
 import rehypeSlug from "rehype-slug";
 import rehypeToc from "@jsdevtools/rehype-toc";
 import { create_toc_element } from "~src/utils";
@@ -39,14 +39,15 @@ const ballots = await db
     .execute();
 
 const md = `
-${proposal.summary ? `# Yhteenveto\n\n${proposal.summary}` : ""}
-${proposal.reasoning ? `# Perustelut\n\n${proposal.reasoning}` : ""}
-${proposal.law_changes ? `# Lakimuutokset\n\n${proposal.law_changes}` : ""}
+${proposal.summary ? proposal.summary : ""}
+${proposal.reasoning ? proposal.reasoning : ""}
+${proposal.law_changes ? proposal.law_changes : ""}
 `;
 
 const content = await rehype()
     .use(rehypeSlug)
     .use(rehypeAutolinkHeadings)
+    .use(rehypeShiftHeading, { shift: 1 })
     .use(rehypeToc, {
         customizeTOC: (a) => {
             if (ballots.length > 0) {


### PR DESCRIPTION
we currently store the markdown data in the db so that the first heading is of level 1 (as it should be). however, when showing many of those documents on the proposal page (summary, reasoning, law_changes), we would have multiple level 1 headings in the output HTML. this is against accessibility best practices, so we use the heading leveling rehype plugin to drop all the markdown heading levels down by one, so that the page only has one level 1 heading