### PR TITLE
refactor: read vaski file in batches to avoid oom

### DIFF
--- a/pipes/vaski_parser.py
+++ b/pipes/vaski_parser.py
@@ -1,17 +1,16 @@
 import os.path
 import polars as pl
-from tqdm import tqdm
 
 
 def vaski_parser():
     vaski_fname = os.path.join("data", "raw", "VaskiData.tsv")
 
-    for vaski_data in tqdm(
-        pl.read_csv(vaski_fname, separator="\t", has_header=True).iter_slices(
-            n_rows=10_000
-        ),
-        total=31,
-    ):  # Total achieved by experiment
+    reader = pl.read_csv_batched(
+        vaski_fname, separator="\t", has_header=True, batch_size=1000
+    )
+    batches = reader.next_batches(10)
+    while batches:
+        vaski_data = pl.concat(batches)
         vaski_data = vaski_data.with_columns(
             pl.col("XmlData").str.extract(r"VASKI_JULKVP_(\w+)").alias("doctype")
         )
@@ -22,6 +21,7 @@ def vaski_parser():
             sub_vaski = sub_vaski.drop("doctype")
             with open(f_path, mode="a" if os.path.exists(f_path) else "w") as f:
                 sub_vaski.write_csv(f, separator="\t", include_header=f.mode == "w")
+        batches = reader.next_batches(10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
now reads the whole vaski raw data in small batches to avoid oom